### PR TITLE
Fix destructing

### DIFF
--- a/.changeset/itchy-dolphins-talk.md
+++ b/.changeset/itchy-dolphins-talk.md
@@ -1,0 +1,5 @@
+---
+"@devup-ui/react": patch
+---
+
+Support optional args in css

--- a/.changeset/soft-islands-compete.md
+++ b/.changeset/soft-islands-compete.md
@@ -1,0 +1,5 @@
+---
+"@devup-ui/wasm": patch
+---
+
+Support destructing, Support to direct selection of object with theme, Support for template literal on as prop

--- a/libs/extractor/src/gen_class_name.rs
+++ b/libs/extractor/src/gen_class_name.rs
@@ -16,7 +16,6 @@ pub fn gen_class_names<'a>(
         style_props
             .iter()
             .filter_map(|st| gen_class_name(ast_builder, st))
-            .rev()
             .collect(),
     )
 }

--- a/libs/extractor/src/gen_class_name.rs
+++ b/libs/extractor/src/gen_class_name.rs
@@ -16,6 +16,7 @@ pub fn gen_class_names<'a>(
         style_props
             .iter()
             .filter_map(|st| gen_class_name(ast_builder, st))
+            .rev()
             .collect(),
     )
 }

--- a/libs/extractor/src/lib.rs
+++ b/libs/extractor/src/lib.rs
@@ -837,6 +837,19 @@ mod tests {
             }
         )
         .unwrap());
+        //
+        //         reset_class_map();
+        //         assert_debug_snapshot!(extract(
+        //             "test.tsx",
+        //             r#"import { css } from "@devup-ui/core";
+        // <div className={css(a?{bg:"red"}:{bg:"blue"})}/>;
+        // "#,
+        //             ExtractOption {
+        //                 package: "@devup-ui/core".to_string(),
+        //                 css_file: None
+        //             }
+        //         )
+        //         .unwrap());
     }
 
     #[test]
@@ -1347,7 +1360,7 @@ PROCESS_DATA.map(({ id, title, content }, idx) => (
         )
         .unwrap());
     }
-    
+
     #[test]
     #[serial]
     fn avoid_same_name_component() {
@@ -1366,4 +1379,24 @@ import {Button} from '@devup/ui'
         )
         .unwrap());
     }
+
+    //     #[test]
+    //     #[serial]
+    //     fn css_props_destructuring_assignment() {
+    //         reset_class_map();
+    //         assert_debug_snapshot!(extract(
+    //             "test.js",
+    //             r#"import {css} from '@devup-ui/core'
+    // <div className={css({
+    //    ...(a ? { bg: 'red' } : { bg: 'blue' }),
+    //    ...({ p: 1 }),
+    //  })} />
+    //         "#,
+    //             ExtractOption {
+    //                 package: "@devup-ui/core".to_string(),
+    //                 css_file: None
+    //             }
+    //         )
+    //         .unwrap());
+    //     }
 }

--- a/libs/extractor/src/lib.rs
+++ b/libs/extractor/src/lib.rs
@@ -181,6 +181,92 @@ mod tests {
         )
         .unwrap());
     }
+
+    #[test]
+    #[serial]
+    fn convert_tag() {
+        reset_class_map();
+        assert_debug_snapshot!(extract(
+            "test.tsx",
+            r#"import {Box} from '@devup-ui/core'
+        <Box as="secton" />
+        "#,
+            ExtractOption {
+                package: "@devup-ui/core".to_string(),
+                css_file: None
+            }
+        )
+        .unwrap());
+
+        reset_class_map();
+        assert_debug_snapshot!(extract(
+            "test.tsx",
+            r#"import {Box} from '@devup-ui/core'
+        <Box as={"secton"} />
+        "#,
+            ExtractOption {
+                package: "@devup-ui/core".to_string(),
+                css_file: None
+            }
+        )
+        .unwrap());
+        assert_debug_snapshot!(extract(
+            "test.tsx",
+            r#"import {Box} from '@devup-ui/core'
+        <Box as={`secton`} />
+        "#,
+            ExtractOption {
+                package: "@devup-ui/core".to_string(),
+                css_file: None
+            }
+        )
+        .unwrap());
+        // assert_debug_snapshot!(extract(
+        //     "test.tsx",
+        //     r#"import {Box} from '@devup-ui/core'
+        // <Box as={b ? "div":"secton"} />
+        // "#,
+        //     ExtractOption {
+        //         package: "@devup-ui/core".to_string(),
+        //         css_file: None
+        //     }
+        // )
+        // .unwrap());
+        // assert_debug_snapshot!(extract(
+        //     "test.tsx",
+        //     r#"import {Box} from '@devup-ui/core'
+        // <Box as={b ? undefined:"secton"} />
+        // "#,
+        //     ExtractOption {
+        //         package: "@devup-ui/core".to_string(),
+        //         css_file: None
+        //     }
+        // )
+        // .unwrap());
+        //
+        // assert_debug_snapshot!(extract(
+        //     "test.tsx",
+        //     r#"import {Box} from '@devup-ui/core'
+        // <Box as={b ? null:"secton"} />
+        // "#,
+        //     ExtractOption {
+        //         package: "@devup-ui/core".to_string(),
+        //         css_file: None
+        //     }
+        // )
+        // .unwrap());
+        // assert_debug_snapshot!(extract(
+        //     "test.tsx",
+        //     r#"import {Box} from '@devup-ui/core'
+        // <Box as={b ? null:undefined} />
+        // "#,
+        //     ExtractOption {
+        //         package: "@devup-ui/core".to_string(),
+        //         css_file: None
+        //     }
+        // )
+        // .unwrap());
+    }
     #[test]
     #[serial]
     fn extract_style_props() {
@@ -837,19 +923,19 @@ mod tests {
             }
         )
         .unwrap());
-        //
-        //         reset_class_map();
-        //         assert_debug_snapshot!(extract(
-        //             "test.tsx",
-        //             r#"import { css } from "@devup-ui/core";
-        // <div className={css(a?{bg:"red"}:{bg:"blue"})}/>;
-        // "#,
-        //             ExtractOption {
-        //                 package: "@devup-ui/core".to_string(),
-        //                 css_file: None
-        //             }
-        //         )
-        //         .unwrap());
+
+        reset_class_map();
+        assert_debug_snapshot!(extract(
+            "test.tsx",
+            r#"import { css } from "@devup-ui/core";
+        <div className={css(a?{bg:"red"}:{bg:"blue"})}/>;
+        "#,
+            ExtractOption {
+                package: "@devup-ui/core".to_string(),
+                css_file: None
+            }
+        )
+        .unwrap());
     }
 
     #[test]
@@ -860,6 +946,32 @@ mod tests {
             "test.tsx",
             r#"import {Box} from '@devup-ui/core'
         <Box color="$nice" />
+        "#,
+            ExtractOption {
+                package: "@devup-ui/core".to_string(),
+                css_file: None
+            }
+        )
+        .unwrap());
+
+        reset_class_map();
+        assert_debug_snapshot!(extract(
+            "test.tsx",
+            r#"import {Box} from '@devup-ui/core'
+        <Box color={`$nice`} />
+        "#,
+            ExtractOption {
+                package: "@devup-ui/core".to_string(),
+                css_file: None
+            }
+        )
+        .unwrap());
+
+        reset_class_map();
+        assert_debug_snapshot!(extract(
+            "test.tsx",
+            r#"import {Box} from '@devup-ui/core'
+        <Box color={("$nice")} />
         "#,
             ExtractOption {
                 package: "@devup-ui/core".to_string(),
@@ -1273,6 +1385,33 @@ export {
             }
         )
         .unwrap());
+
+        reset_class_map();
+        assert_debug_snapshot!(extract(
+            "test.js",
+            r#"import {Center} from '@devup-ui/core'
+<Center bg={SOME_VAR[idx]}>
+          </Center>
+        "#,
+            ExtractOption {
+                package: "@devup-ui/core".to_string(),
+                css_file: None
+            }
+        )
+        .unwrap());
+
+        reset_class_map();
+        assert_debug_snapshot!(extract(
+            "test.js",
+            r#"import {Flex} from '@devup-ui/core'
+        <Flex bg={{a:"$red", b:"$blue"}[idx]} />
+        "#,
+            ExtractOption {
+                package: "@devup-ui/core".to_string(),
+                css_file: None
+            }
+        )
+        .unwrap());
     }
 
     #[test]
@@ -1380,23 +1519,23 @@ import {Button} from '@devup/ui'
         .unwrap());
     }
 
-    //     #[test]
-    //     #[serial]
-    //     fn css_props_destructuring_assignment() {
-    //         reset_class_map();
-    //         assert_debug_snapshot!(extract(
-    //             "test.js",
-    //             r#"import {css} from '@devup-ui/core'
-    // <div className={css({
-    //    ...(a ? { bg: 'red' } : { bg: 'blue' }),
-    //    ...({ p: 1 }),
-    //  })} />
-    //         "#,
-    //             ExtractOption {
-    //                 package: "@devup-ui/core".to_string(),
-    //                 css_file: None
-    //             }
-    //         )
-    //         .unwrap());
-    //     }
+    #[test]
+    #[serial]
+    fn css_props_destructuring_assignment() {
+        reset_class_map();
+        assert_debug_snapshot!(extract(
+            "test.js",
+            r#"import {css} from '@devup-ui/core'
+    <div className={css({
+       ...(a ? { bg: 'red' } : { bg: 'blue' }),
+       ...({ p: 1 }),
+     })} />
+            "#,
+            ExtractOption {
+                package: "@devup-ui/core".to_string(),
+                css_file: None
+            }
+        )
+        .unwrap());
+    }
 }

--- a/libs/extractor/src/prop_modify_utils.rs
+++ b/libs/extractor/src/prop_modify_utils.rs
@@ -14,7 +14,7 @@ use oxc_span::SPAN;
 pub fn modify_prop_object<'a>(
     ast_builder: &AstBuilder<'a>,
     props: &mut oxc_allocator::Vec<ObjectPropertyKind<'a>>,
-    styles: Vec<ExtractStyleProp<'a>>,
+    styles: &[ExtractStyleProp<'a>],
 ) {
     let mut class_name_prop = None;
     let mut style_prop = None;
@@ -38,7 +38,7 @@ pub fn modify_prop_object<'a>(
     }
 
     // should modify class name prop
-    if let Some(ex) = gen_class_names(ast_builder, &styles) {
+    if let Some(ex) = gen_class_names(ast_builder, styles) {
         if let Some(pr) = if let Some(class_name_prop) = class_name_prop {
             merge_expression_for_class_name(
                 ast_builder,
@@ -76,7 +76,7 @@ pub fn modify_prop_object<'a>(
     }
 
     // should modify style prop
-    if let Some(mut ex) = gen_styles(ast_builder, &styles) {
+    if let Some(mut ex) = gen_styles(ast_builder, styles) {
         props.push(if let Some(style_prop) = style_prop {
             ObjectPropertyKind::ObjectProperty(ast_builder.alloc_object_property(
                 SPAN,
@@ -117,7 +117,7 @@ pub fn modify_prop_object<'a>(
 pub fn modify_props<'a>(
     ast_builder: &AstBuilder<'a>,
     props: &mut oxc_allocator::Vec<JSXAttributeItem<'a>>,
-    styles: Vec<ExtractStyleProp<'a>>,
+    styles: &Vec<ExtractStyleProp<'a>>,
 ) {
     let mut class_name_prop = None;
     let mut style_prop = None;
@@ -141,7 +141,7 @@ pub fn modify_props<'a>(
     }
 
     // should modify class name prop
-    if let Some(ex) = gen_class_names(ast_builder, &styles) {
+    if let Some(ex) = gen_class_names(ast_builder, styles) {
         let mut attr = if let Some(class_name_prop) = class_name_prop {
             class_name_prop
         } else {
@@ -160,7 +160,7 @@ pub fn modify_props<'a>(
     }
 
     // should modify style prop
-    if let Some(ex) = gen_styles(ast_builder, &styles) {
+    if let Some(ex) = gen_styles(ast_builder, styles) {
         let mut attr = if let Some(style_prop) = style_prop {
             style_prop
         } else {

--- a/libs/extractor/src/prop_modify_utils.rs
+++ b/libs/extractor/src/prop_modify_utils.rs
@@ -117,7 +117,7 @@ pub fn modify_prop_object<'a>(
 pub fn modify_props<'a>(
     ast_builder: &AstBuilder<'a>,
     props: &mut oxc_allocator::Vec<JSXAttributeItem<'a>>,
-    styles: &Vec<ExtractStyleProp<'a>>,
+    styles: &[ExtractStyleProp<'a>],
 ) {
     let mut class_name_prop = None;
     let mut style_prop = None;

--- a/libs/extractor/src/snapshots/extractor__tests__convert_tag-2.snap
+++ b/libs/extractor/src/snapshots/extractor__tests__convert_tag-2.snap
@@ -1,0 +1,8 @@
+---
+source: libs/extractor/src/lib.rs
+expression: "extract(\"test.tsx\",\nr#\"import {Box} from '@devup-ui/core'\n        <Box as={\"secton\"} />\n        \"#,\nExtractOption\n{ package: \"@devup-ui/core\".to_string(), css_file: None }).unwrap()"
+---
+ExtractOutput {
+    styles: [],
+    code: "<secton />;\n",
+}

--- a/libs/extractor/src/snapshots/extractor__tests__convert_tag-3.snap
+++ b/libs/extractor/src/snapshots/extractor__tests__convert_tag-3.snap
@@ -1,0 +1,8 @@
+---
+source: libs/extractor/src/lib.rs
+expression: "extract(\"test.tsx\",\nr#\"import {Box} from '@devup-ui/core'\n        <Box as={`secton`} />\n        \"#,\nExtractOption\n{ package: \"@devup-ui/core\".to_string(), css_file: None }).unwrap()"
+---
+ExtractOutput {
+    styles: [],
+    code: "<secton />;\n",
+}

--- a/libs/extractor/src/snapshots/extractor__tests__convert_tag.snap
+++ b/libs/extractor/src/snapshots/extractor__tests__convert_tag.snap
@@ -1,0 +1,8 @@
+---
+source: libs/extractor/src/lib.rs
+expression: "extract(\"test.tsx\",\nr#\"import {Box} from '@devup-ui/core'\n        <Box as=\"secton\" />\n        \"#,\nExtractOption\n{ package: \"@devup-ui/core\".to_string(), css_file: None }).unwrap()"
+---
+ExtractOutput {
+    styles: [],
+    code: "<secton />;\n",
+}

--- a/libs/extractor/src/snapshots/extractor__tests__css_props_destructuring_assignment.snap
+++ b/libs/extractor/src/snapshots/extractor__tests__css_props_destructuring_assignment.snap
@@ -1,0 +1,36 @@
+---
+source: libs/extractor/src/lib.rs
+expression: "extract(\"test.js\",\nr#\"import {css} from '@devup-ui/core'\n    <div className={css({\n       ...(a ? { bg: 'red' } : { bg: 'blue' }),\n       ...({ p: 1 }),\n     })} />\n            \"#,\nExtractOption\n{ package: \"@devup-ui/core\".to_string(), css_file: None }).unwrap()"
+---
+ExtractOutput {
+    styles: [
+        Static(
+            ExtractStaticStyle {
+                property: "padding",
+                value: "4px",
+                level: 0,
+                selector: None,
+                basic: false,
+            },
+        ),
+        Static(
+            ExtractStaticStyle {
+                property: "background",
+                value: "red",
+                level: 0,
+                selector: None,
+                basic: false,
+            },
+        ),
+        Static(
+            ExtractStaticStyle {
+                property: "background",
+                value: "blue",
+                level: 0,
+                selector: None,
+                basic: false,
+            },
+        ),
+    ],
+    code: "import \"@devup-ui/core/devup-ui.css\";\nimport { css } from \"@devup-ui/core\";\n<div className={css(`d2 ${a ? \"d0\" : \"d1\"}`)} />;\n",
+}

--- a/libs/extractor/src/snapshots/extractor__tests__extract_static_css_class_name_props-5.snap
+++ b/libs/extractor/src/snapshots/extractor__tests__extract_static_css_class_name_props-5.snap
@@ -6,8 +6,8 @@ ExtractOutput {
     styles: [
         Static(
             ExtractStaticStyle {
-                property: "color",
-                value: "blue",
+                property: "background",
+                value: "red",
                 level: 0,
                 selector: Some(
                     Postfix(
@@ -19,8 +19,8 @@ ExtractOutput {
         ),
         Static(
             ExtractStaticStyle {
-                property: "background",
-                value: "red",
+                property: "color",
+                value: "blue",
                 level: 0,
                 selector: Some(
                     Postfix(

--- a/libs/extractor/src/snapshots/extractor__tests__extract_static_css_class_name_props-6.snap
+++ b/libs/extractor/src/snapshots/extractor__tests__extract_static_css_class_name_props-6.snap
@@ -1,0 +1,27 @@
+---
+source: libs/extractor/src/lib.rs
+expression: "extract(\"test.tsx\",\nr#\"import { css } from \"@devup-ui/core\";\n        <div className={css(a?{bg:\"red\"}:{bg:\"blue\"})}/>;\n        \"#,\nExtractOption\n{ package: \"@devup-ui/core\".to_string(), css_file: None }).unwrap()"
+---
+ExtractOutput {
+    styles: [
+        Static(
+            ExtractStaticStyle {
+                property: "background",
+                value: "red",
+                level: 0,
+                selector: None,
+                basic: false,
+            },
+        ),
+        Static(
+            ExtractStaticStyle {
+                property: "background",
+                value: "blue",
+                level: 0,
+                selector: None,
+                basic: false,
+            },
+        ),
+    ],
+    code: "import \"@devup-ui/core/devup-ui.css\";\nimport { css } from \"@devup-ui/core\";\n<div className={css(a ? \"d0\" : \"d1\")} />;\n",
+}

--- a/libs/extractor/src/snapshots/extractor__tests__extract_static_css_with_theme-2.snap
+++ b/libs/extractor/src/snapshots/extractor__tests__extract_static_css_with_theme-2.snap
@@ -1,0 +1,18 @@
+---
+source: libs/extractor/src/lib.rs
+expression: "extract(\"test.tsx\",\nr#\"import {Box} from '@devup-ui/core'\n        <Box color={`$nice`} />\n        \"#,\nExtractOption\n{ package: \"@devup-ui/core\".to_string(), css_file: None }).unwrap()"
+---
+ExtractOutput {
+    styles: [
+        Static(
+            ExtractStaticStyle {
+                property: "color",
+                value: "$nice",
+                level: 0,
+                selector: None,
+                basic: false,
+            },
+        ),
+    ],
+    code: "import \"@devup-ui/core/devup-ui.css\";\n<div className=\"d0\" />;\n",
+}

--- a/libs/extractor/src/snapshots/extractor__tests__extract_static_css_with_theme-3.snap
+++ b/libs/extractor/src/snapshots/extractor__tests__extract_static_css_with_theme-3.snap
@@ -1,0 +1,18 @@
+---
+source: libs/extractor/src/lib.rs
+expression: "extract(\"test.tsx\",\nr#\"import {Box} from '@devup-ui/core'\n        <Box color={(\"$nice\")} />\n        \"#,\nExtractOption\n{ package: \"@devup-ui/core\".to_string(), css_file: None }).unwrap()"
+---
+ExtractOutput {
+    styles: [
+        Static(
+            ExtractStaticStyle {
+                property: "color",
+                value: "$nice",
+                level: 0,
+                selector: None,
+                basic: false,
+            },
+        ),
+    ],
+    code: "import \"@devup-ui/core/devup-ui.css\";\n<div className=\"d0\" />;\n",
+}

--- a/libs/extractor/src/snapshots/extractor__tests__props_direct_select-12.snap
+++ b/libs/extractor/src/snapshots/extractor__tests__props_direct_select-12.snap
@@ -1,0 +1,44 @@
+---
+source: libs/extractor/src/lib.rs
+expression: "extract(\"test.js\",\nr#\"import {Center} from '@devup-ui/core'\n<Center bg={SOME_VAR[idx]}>\n          </Center>\n        \"#,\nExtractOption\n{ package: \"@devup-ui/core\".to_string(), css_file: None }).unwrap()"
+---
+ExtractOutput {
+    styles: [
+        Static(
+            ExtractStaticStyle {
+                property: "display",
+                value: "flex",
+                level: 0,
+                selector: None,
+                basic: true,
+            },
+        ),
+        Static(
+            ExtractStaticStyle {
+                property: "justifyContent",
+                value: "center",
+                level: 0,
+                selector: None,
+                basic: true,
+            },
+        ),
+        Static(
+            ExtractStaticStyle {
+                property: "alignItems",
+                value: "center",
+                level: 0,
+                selector: None,
+                basic: true,
+            },
+        ),
+        Dynamic(
+            ExtractDynamicStyle {
+                property: "background",
+                level: 0,
+                identifier: "SOME_VAR[idx]",
+                selector: None,
+            },
+        ),
+    ],
+    code: "import \"@devup-ui/core/devup-ui.css\";\n<div className=\"d0 d1 d2 d3\" style={{ \"--d4\": SOME_VAR[idx] }}>\n          </div>;\n",
+}

--- a/libs/extractor/src/snapshots/extractor__tests__props_direct_select-13.snap
+++ b/libs/extractor/src/snapshots/extractor__tests__props_direct_select-13.snap
@@ -1,0 +1,26 @@
+---
+source: libs/extractor/src/lib.rs
+expression: "extract(\"test.js\",\nr#\"import {Flex} from '@devup-ui/core'\n        <Flex bg={{a:\"$red\", b:\"$blue\"}[idx]} />\n        \"#,\nExtractOption\n{ package: \"@devup-ui/core\".to_string(), css_file: None }).unwrap()"
+---
+ExtractOutput {
+    styles: [
+        Static(
+            ExtractStaticStyle {
+                property: "display",
+                value: "flex",
+                level: 0,
+                selector: None,
+                basic: true,
+            },
+        ),
+        Dynamic(
+            ExtractDynamicStyle {
+                property: "background",
+                level: 0,
+                identifier: "({\n\ta: \"var(--red)\",\n\tb: \"var(--blue)\"\n})[idx]",
+                selector: None,
+            },
+        ),
+    ],
+    code: "import \"@devup-ui/core/devup-ui.css\";\n<div className=\"d0 d1\" style={{ \"--d2\": ({\n\ta: \"var(--red)\",\n\tb: \"var(--blue)\"\n})[idx] }} />;\n",
+}

--- a/libs/extractor/src/visit.rs
+++ b/libs/extractor/src/visit.rs
@@ -118,125 +118,92 @@ impl<'a> VisitMut<'a> for DevupVisitor<'a> {
                 };
                 if let Some(kind) = element_kind {
                     if it.arguments.len() > 1 {
-                        if let Expression::ObjectExpression(obj) =
-                            it.arguments[1].to_expression_mut()
-                        {
-                            let mut duplicate_set = HashSet::new();
-                            let mut tag = kind.to_tag().unwrap_or("div").to_string();
-                            let mut props_styles = vec![];
-                            for idx in (0..obj.properties.len()).rev() {
-                                let mut prop = obj.properties.remove(idx);
-                                let mut rm = false;
-                                if let ObjectPropertyKind::ObjectProperty(prop) = &mut prop {
-                                    if let PropertyKey::StaticIdentifier(ident) = &prop.key {
-                                        let name = sort_to_long(&ident.name);
-                                        if duplicate_set.contains(name.as_str()) {
-                                            continue;
-                                        }
-                                        duplicate_set.insert(name.clone());
-                                        rm = match extract_style_from_expression(
-                                            &self.ast,
-                                            Some(&name),
-                                            &mut prop.value,
-                                            0,
-                                            None,
-                                        ) {
-                                            ExtractResult::Maintain => false,
-                                            ExtractResult::Remove => true,
-                                            ExtractResult::ExtractStyle(mut styles) => {
-                                                styles.reverse();
-                                                props_styles.append(&mut styles);
-                                                true
-                                            }
-                                            ExtractResult::ChangeTag(t) => {
-                                                tag = t;
-                                                true
-                                            }
-                                        }
-                                    }
-                                }
-                                if !rm {
-                                    obj.properties.insert(idx, prop);
-                                }
+                        let mut tag = kind.to_tag().unwrap_or("div").to_string();
+                        println!("tag {}", tag);
+                        let mut props_styles = vec![];
+                        match extract_style_from_expression(
+                            &self.ast,
+                            None,
+                            it.arguments[1].to_expression_mut(),
+                            0,
+                            None,
+                        ) {
+                            ExtractResult::ExtractStyle(mut styles) => {
+                                props_styles.append(&mut styles);
+                            }
+                            ExtractResult::ExtractStyleWithChangeTag(mut styles, t) => {
+                                tag = t;
+
+                                props_styles.append(&mut styles);
                             }
 
-                            for ex in kind.extract().into_iter().rev() {
-                                props_styles.push(ExtractStyleProp::Static(ex));
+                            ExtractResult::Maintain => {
+                                println!("maintain");
                             }
-
-                            for style in props_styles.iter().rev() {
-                                self.styles.append(&mut style.extract());
+                            ExtractResult::Remove => {
+                                println!("remove");
                             }
-
-                            modify_prop_object(&self.ast, &mut obj.properties, props_styles);
-                            it.arguments[0] =
-                                Argument::StringLiteral(self.ast.alloc_string_literal(
-                                    SPAN,
-                                    self.ast.atom(tag.as_str()),
-                                    None,
-                                ));
+                            ExtractResult::ChangeTag(t) => {
+                                tag = t;
+                                println!("tag {}", tag);
+                            }
                         }
+
+                        for ex in kind.extract().into_iter().rev() {
+                            props_styles.push(ExtractStyleProp::Static(ex));
+                        }
+
+                        for style in props_styles.iter().rev() {
+                            self.styles.append(&mut style.extract());
+                        }
+
+                        it.arguments[0] = Argument::StringLiteral(self.ast.alloc_string_literal(
+                            SPAN,
+                            self.ast.atom(tag.as_str()),
+                            None,
+                        ));
                     }
                 }
             }
         }
         if let Expression::Identifier(ident) = &it.callee {
             if self.css_imports.contains_key(ident.name.as_str()) && it.arguments.len() == 1 {
-                if let Argument::ObjectExpression(ref mut obj) = it.arguments[0] {
-                    let mut props_styles = vec![];
-                    for idx in (0..obj.properties.len()).rev() {
-                        let mut prop = obj.properties.remove(idx);
-                        let mut rm = false;
-                        if let ObjectPropertyKind::ObjectProperty(prop) = &mut prop {
-                            if let PropertyKey::StaticIdentifier(ident) = &prop.key {
-                                let name = ident.name.to_string();
-                                rm = match extract_style_from_expression(
-                                    &self.ast,
-                                    Some(&name),
-                                    &mut prop.value,
-                                    0,
-                                    None,
-                                ) {
-                                    ExtractResult::Maintain => false,
-                                    ExtractResult::Remove => true,
-                                    ExtractResult::ExtractStyle(mut styles) => {
-                                        styles.reverse();
-                                        props_styles.append(&mut styles);
-                                        true
+                match extract_style_from_expression(
+                    &self.ast,
+                    None,
+                    it.arguments[0].to_expression_mut(),
+                    0,
+                    None,
+                ) {
+                    ExtractResult::ExtractStyle(mut styles)
+                    | ExtractResult::ExtractStyleWithChangeTag(mut styles, _) => {
+                        let mut styles = styles
+                            .into_iter()
+                            .flat_map(|ex| ex.extract())
+                            .collect::<Vec<_>>();
+                        let class_name = styles
+                            .iter()
+                            .filter_map(|ex| match ex {
+                                ExtractStyleValue::Static(css) => {
+                                    if let StyleProperty::ClassName(cls) = css.extract() {
+                                        Some(cls.to_string())
+                                    } else {
+                                        None
                                     }
-                                    ExtractResult::ChangeTag(_) => true,
                                 }
-                            }
-                        }
-                        if !rm {
-                            obj.properties.insert(idx, prop);
-                        }
-                    }
-                    let mut styles = props_styles
-                        .into_iter()
-                        .flat_map(|ex| ex.extract())
-                        .collect::<Vec<_>>();
-                    let class_name = styles
-                        .iter()
-                        .filter_map(|ex| match ex {
-                            ExtractStyleValue::Static(css) => {
-                                if let StyleProperty::ClassName(cls) = css.extract() {
-                                    Some(cls.to_string())
-                                } else {
-                                    None
-                                }
-                            }
-                            _ => None,
-                        })
-                        .collect::<Vec<_>>()
-                        .join(" ");
+                                _ => None,
+                            })
+                            .collect::<Vec<_>>()
+                            .join(" ");
 
-                    self.styles.append(&mut styles);
-                    it.arguments[0] = Argument::StringLiteral(self.ast.alloc_string_literal(
-                        SPAN,
-                        self.ast.atom(&class_name),
-                        None,
-                    ));
+                        self.styles.append(&mut styles);
+                        it.arguments[0] = Argument::StringLiteral(self.ast.alloc_string_literal(
+                            SPAN,
+                            self.ast.atom(&class_name),
+                            None,
+                        ));
+                    }
+                    _ => {}
                 }
             }
         }
@@ -283,7 +250,6 @@ impl<'a> VisitMut<'a> for DevupVisitor<'a> {
 
         let opening_element = &mut elem.opening_element;
         let component_name = &opening_element.name.to_string();
-        println!("component_name: {} {:?}", component_name, self.imports);
         if let Some(kind) = self.imports.get(component_name) {
             let attrs = &mut opening_element.attributes;
             let mut tag_name = kind.to_tag().unwrap_or("div").to_string();
@@ -314,6 +280,12 @@ impl<'a> VisitMut<'a> for DevupVisitor<'a> {
                                     tag_name = tag;
                                     true
                                 }
+                                ExtractResult::ExtractStyleWithChangeTag(mut styles, tag) => {
+                                    styles.reverse();
+                                    props_styles.append(&mut styles);
+                                    tag_name = tag;
+                                    true
+                                }
                             }
                         }
                     }
@@ -330,7 +302,7 @@ impl<'a> VisitMut<'a> for DevupVisitor<'a> {
                 self.styles.append(&mut style.extract());
             }
             // modify!!
-            modify_props(&self.ast, attrs, props_styles);
+            modify_props(&self.ast, attrs, &props_styles);
 
             // change tag name
             let ident = JSXElementName::Identifier(self.ast.alloc_jsx_identifier(SPAN, tag_name));

--- a/packages/react/src/utils/__tests__/index.test.ts
+++ b/packages/react/src/utils/__tests__/index.test.ts
@@ -4,5 +4,6 @@ describe('css', () => {
   it('should return className', async () => {
     expect(css`virtual-css`).toEqual('virtual-css')
     expect(css('class name' as any)).toEqual('class name')
+    expect(css()).toEqual('')
   })
 })

--- a/packages/react/src/utils/css.ts
+++ b/packages/react/src/utils/css.ts
@@ -3,10 +3,12 @@ import type { DevupSelectorProps } from '../types/props/selector'
 
 export function css(props: DevupCommonProps & DevupSelectorProps): string
 export function css(strings: TemplateStringsArray): string
+export function css(): string
 
 export function css(
-  strings: TemplateStringsArray | (DevupCommonProps & DevupSelectorProps),
+  strings?: TemplateStringsArray | (DevupCommonProps & DevupSelectorProps),
 ): string {
+  if (typeof strings === 'undefined') return ''
   if (Array.isArray(strings)) {
     return strings.join('')
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -139,13 +139,13 @@ importers:
         version: 19.0.3(@types/react@19.0.7)
       '@vitejs/plugin-react':
         specifier: ^4.3.4
-        version: 4.3.4(vite@6.0.10(@types/node@22.10.7)(terser@5.37.0))
+        version: 4.3.4(vite@6.0.11(@types/node@22.10.7)(terser@5.37.0))
       typescript:
         specifier: ^5
         version: 5.7.3
       vite:
         specifier: ^6
-        version: 6.0.10(@types/node@22.10.7)(terser@5.37.0)
+        version: 6.0.11(@types/node@22.10.7)(terser@5.37.0)
 
   apps/vite-lib:
     dependencies:
@@ -157,7 +157,7 @@ importers:
         version: 19.0.0
       vite:
         specifier: ^6
-        version: 6.0.10(@types/node@22.10.7)(terser@5.37.0)
+        version: 6.0.11(@types/node@22.10.7)(terser@5.37.0)
     devDependencies:
       '@devup-ui/vite-plugin':
         specifier: workspace:*
@@ -170,13 +170,13 @@ importers:
         version: 19.0.7
       '@vitejs/plugin-react':
         specifier: ^4.3.4
-        version: 4.3.4(vite@6.0.10(@types/node@22.10.7)(terser@5.37.0))
+        version: 4.3.4(vite@6.0.11(@types/node@22.10.7)(terser@5.37.0))
       typescript:
         specifier: ^5
         version: 5.7.3
       vite-plugin-dts:
         specifier: ^4.5.0
-        version: 4.5.0(@types/node@22.10.7)(rollup@4.31.0)(typescript@5.7.3)(vite@6.0.10(@types/node@22.10.7)(terser@5.37.0))
+        version: 4.5.0(@types/node@22.10.7)(rollup@4.31.0)(typescript@5.7.3)(vite@6.0.11(@types/node@22.10.7)(terser@5.37.0))
 
   benchmark/next-chakra-ui:
     dependencies:
@@ -293,10 +293,10 @@ importers:
         version: 5.7.3
       vite:
         specifier: ^6
-        version: 6.0.10(@types/node@22.10.7)(terser@5.37.0)
+        version: 6.0.11(@types/node@22.10.7)(terser@5.37.0)
       vite-plugin-dts:
         specifier: ^4.5.0
-        version: 4.5.0(@types/node@22.10.7)(rollup@4.31.0)(typescript@5.7.3)(vite@6.0.10(@types/node@22.10.7)(terser@5.37.0))
+        version: 4.5.0(@types/node@22.10.7)(rollup@4.31.0)(typescript@5.7.3)(vite@6.0.11(@types/node@22.10.7)(terser@5.37.0))
       vitest:
         specifier: ^3.0.3
         version: 3.0.3(@types/node@22.10.7)(terser@5.37.0)
@@ -318,10 +318,10 @@ importers:
         version: 5.7.3
       vite:
         specifier: ^6
-        version: 6.0.10(@types/node@22.10.7)(terser@5.37.0)
+        version: 6.0.11(@types/node@22.10.7)(terser@5.37.0)
       vite-plugin-dts:
         specifier: ^4.5.0
-        version: 4.5.0(@types/node@22.10.7)(rollup@4.31.0)(typescript@5.7.3)(vite@6.0.10(@types/node@22.10.7)(terser@5.37.0))
+        version: 4.5.0(@types/node@22.10.7)(rollup@4.31.0)(typescript@5.7.3)(vite@6.0.11(@types/node@22.10.7)(terser@5.37.0))
       vitest:
         specifier: ^3.0.3
         version: 3.0.3(@types/node@22.10.7)(terser@5.37.0)
@@ -333,14 +333,14 @@ importers:
         version: link:../../bindings/devup-ui-wasm
       vite:
         specifier: ^6
-        version: 6.0.10(@types/node@22.10.7)(terser@5.37.0)
+        version: 6.0.11(@types/node@22.10.7)(terser@5.37.0)
     devDependencies:
       typescript:
         specifier: ^5.7.3
         version: 5.7.3
       vite-plugin-dts:
         specifier: ^4.5.0
-        version: 4.5.0(@types/node@22.10.7)(rollup@4.31.0)(typescript@5.7.3)(vite@6.0.10(@types/node@22.10.7)(terser@5.37.0))
+        version: 4.5.0(@types/node@22.10.7)(rollup@4.31.0)(typescript@5.7.3)(vite@6.0.11(@types/node@22.10.7)(terser@5.37.0))
 
   packages/webpack-plugin:
     dependencies:
@@ -356,10 +356,10 @@ importers:
         version: 5.7.3
       vite:
         specifier: ^6
-        version: 6.0.10(@types/node@22.10.7)(terser@5.37.0)
+        version: 6.0.11(@types/node@22.10.7)(terser@5.37.0)
       vite-plugin-dts:
         specifier: ^4.5.0
-        version: 4.5.0(@types/node@22.10.7)(rollup@4.31.0)(typescript@5.7.3)(vite@6.0.10(@types/node@22.10.7)(terser@5.37.0))
+        version: 4.5.0(@types/node@22.10.7)(rollup@4.31.0)(typescript@5.7.3)(vite@6.0.11(@types/node@22.10.7)(terser@5.37.0))
       vitest:
         specifier: ^3.0.3
         version: 3.0.3(@types/node@22.10.7)(terser@5.37.0)
@@ -4450,8 +4450,8 @@ packages:
       vite:
         optional: true
 
-  vite@6.0.10:
-    resolution: {integrity: sha512-MEszunEcMo6pFsfXN1GhCFQqnE25tWRH0MA4f0Q7uanACi4y1Us+ZGpTMnITwCTnYzB2b9cpmnelTlxgTBmaBA==}
+  vite@6.0.11:
+    resolution: {integrity: sha512-4VL9mQPKoHy4+FE0NnRE/kbY51TOfaknxAjt3fJbGJxhIpBZiqVzlZDEesWWsuREXHwNdAoOFZ9MkPEVXczHwg==}
     engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
     hasBin: true
     peerDependencies:
@@ -6469,14 +6469,14 @@ snapshots:
 
   '@ungap/structured-clone@1.2.1': {}
 
-  '@vitejs/plugin-react@4.3.4(vite@6.0.10(@types/node@22.10.7)(terser@5.37.0))':
+  '@vitejs/plugin-react@4.3.4(vite@6.0.11(@types/node@22.10.7)(terser@5.37.0))':
     dependencies:
       '@babel/core': 7.26.0
       '@babel/plugin-transform-react-jsx-self': 7.25.9(@babel/core@7.26.0)
       '@babel/plugin-transform-react-jsx-source': 7.25.9(@babel/core@7.26.0)
       '@types/babel__core': 7.20.5
       react-refresh: 0.14.2
-      vite: 6.0.10(@types/node@22.10.7)(terser@5.37.0)
+      vite: 6.0.11(@types/node@22.10.7)(terser@5.37.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -6505,13 +6505,13 @@ snapshots:
       chai: 5.1.2
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.0.3(vite@6.0.10(@types/node@22.10.7)(terser@5.37.0))':
+  '@vitest/mocker@3.0.3(vite@6.0.11(@types/node@22.10.7)(terser@5.37.0))':
     dependencies:
       '@vitest/spy': 3.0.3
       estree-walker: 3.0.3
       magic-string: 0.30.17
     optionalDependencies:
-      vite: 6.0.10(@types/node@22.10.7)(terser@5.37.0)
+      vite: 6.0.11(@types/node@22.10.7)(terser@5.37.0)
 
   '@vitest/pretty-format@3.0.3':
     dependencies:
@@ -9807,7 +9807,7 @@ snapshots:
       debug: 4.4.0
       es-module-lexer: 1.6.0
       pathe: 2.0.2
-      vite: 6.0.10(@types/node@22.10.7)(terser@5.37.0)
+      vite: 6.0.11(@types/node@22.10.7)(terser@5.37.0)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -9822,7 +9822,7 @@ snapshots:
       - tsx
       - yaml
 
-  vite-plugin-dts@4.5.0(@types/node@22.10.7)(rollup@4.31.0)(typescript@5.7.3)(vite@6.0.10(@types/node@22.10.7)(terser@5.37.0)):
+  vite-plugin-dts@4.5.0(@types/node@22.10.7)(rollup@4.31.0)(typescript@5.7.3)(vite@6.0.11(@types/node@22.10.7)(terser@5.37.0)):
     dependencies:
       '@microsoft/api-extractor': 7.49.1(@types/node@22.10.7)
       '@rollup/pluginutils': 5.1.4(rollup@4.31.0)
@@ -9835,13 +9835,13 @@ snapshots:
       magic-string: 0.30.17
       typescript: 5.7.3
     optionalDependencies:
-      vite: 6.0.10(@types/node@22.10.7)(terser@5.37.0)
+      vite: 6.0.11(@types/node@22.10.7)(terser@5.37.0)
     transitivePeerDependencies:
       - '@types/node'
       - rollup
       - supports-color
 
-  vite@6.0.10(@types/node@22.10.7)(terser@5.37.0):
+  vite@6.0.11(@types/node@22.10.7)(terser@5.37.0):
     dependencies:
       esbuild: 0.24.2
       postcss: 8.5.1
@@ -9854,7 +9854,7 @@ snapshots:
   vitest@3.0.3(@types/node@22.10.7)(terser@5.37.0):
     dependencies:
       '@vitest/expect': 3.0.3
-      '@vitest/mocker': 3.0.3(vite@6.0.10(@types/node@22.10.7)(terser@5.37.0))
+      '@vitest/mocker': 3.0.3(vite@6.0.11(@types/node@22.10.7)(terser@5.37.0))
       '@vitest/pretty-format': 3.0.3
       '@vitest/runner': 3.0.3
       '@vitest/snapshot': 3.0.3
@@ -9870,7 +9870,7 @@ snapshots:
       tinyexec: 0.3.2
       tinypool: 1.0.2
       tinyrainbow: 2.0.0
-      vite: 6.0.10(@types/node@22.10.7)(terser@5.37.0)
+      vite: 6.0.11(@types/node@22.10.7)(terser@5.37.0)
       vite-node: 3.0.3(@types/node@22.10.7)(terser@5.37.0)
       why-is-node-running: 2.3.0
     optionalDependencies:


### PR DESCRIPTION
## react
- `css` 에 argument 가 없어도 가능하도록 개선
## wasm
- 구조분해할당 지원
- object literal 의 경우 value 가 `$` 로 시작할 경우 `var` 로 변환
- `css` 를 사용할 경우 object 단위의 삼항연산자 지원
- Ident 를 대상으로 indexing 을 할 경우 지원