### PR TITLE
Fix: Code block overflow on mobile in N/M Base docs using responsive grid

### DIFF
--- a/apps/landing/src/app/(detail)/docs/core-concepts/nm-base/page.mdx
+++ b/apps/landing/src/app/(detail)/docs/core-concepts/nm-base/page.mdx
@@ -1,3 +1,5 @@
+import { ExampleGrid } from '@/components/mdx/components/ExampleGrid'
+
 export const metadata = {
   title: 'N/M Base',
   alternates: {
@@ -48,15 +50,7 @@ Class name generation follows these steps:
 
 ### **Basic Class Names**
 
-<div
-  style={{
-    display: 'grid',
-    gridTemplateColumns: '1fr 1fr',
-    gap: '2rem',
-    marginBottom: '2rem',
-    alignItems: 'start',
-  }}
->
+<ExampleGrid>
   <div>
     ```tsx // Input
     <div>
@@ -75,19 +69,11 @@ Class name generation follows these steps:
     </div>
     ```
   </div>
-</div>
+</ExampleGrid>
 
 ### **Responsive Class Names**
 
-<div
-  style={{
-    display: 'grid',
-    gridTemplateColumns: '1fr 1fr',
-    gap: '2rem',
-    marginBottom: '2rem',
-    alignItems: 'start',
-  }}
->
+<ExampleGrid>
   <div>
     ```tsx // Input
     <Box w={[100, 200, 300]} />
@@ -99,19 +85,11 @@ Class name generation follows these steps:
     {/* w: 100px, w: 200px, w: 300px */}
     ```
   </div>
-</div>
+</ExampleGrid>
 
 ### **Pseudo-selector Class Names**
 
-<div
-  style={{
-    display: 'grid',
-    gridTemplateColumns: '1fr 1fr',
-    gap: '2rem',
-    marginBottom: '2rem',
-    alignItems: 'start',
-  }}
->
+<ExampleGrid>
   <div>
     ```tsx
     <Box _hover={{ bg: 'red' }} />
@@ -123,19 +101,11 @@ Class name generation follows these steps:
     {/* .g:hover { background: red; } */}
     ```
   </div>
-</div>
+</ExampleGrid>
 
 ### **File-specific Class Names**
 
-<div
-  style={{
-    display: 'grid',
-    gridTemplateColumns: '1fr 1fr',
-    gap: '2rem',
-    marginBottom: '2rem',
-    alignItems: 'start',
-  }}
->
+<ExampleGrid>
   <div>
     ```tsx
     <div>
@@ -152,7 +122,7 @@ Class name generation follows these steps:
     </div>
     ```
   </div>
-</div>
+</ExampleGrid>
 
 ## Ad-blocker Compatibility
 

--- a/apps/landing/src/components/mdx/components/ExampleGrid.tsx
+++ b/apps/landing/src/components/mdx/components/ExampleGrid.tsx
@@ -1,0 +1,14 @@
+import { Grid } from '@devup-ui/react'
+import { ReactNode } from 'react'
+
+interface ExampleGridProps {
+  children: ReactNode
+}
+
+export function ExampleGrid({ children }: ExampleGridProps) {
+  return (
+    <Grid gap="16px" gridTemplateColumns={['repeat(1, 1fr)', 'repeat(2, 1fr)']}>
+      {children}
+    </Grid>
+  )
+}


### PR DESCRIPTION
> Resolves #475 

## Problem: Code block layout overflow on mobile devices in N/M Base documentation
The code examples in the N/M Base documentation page were displayed using a fixed 2-column grid layout (`gridTemplateColumns: '1fr 1fr'`), causing horizontal overflow and breaking the layout on mobile devices.

</br>

### Root Cause
The N/M Base documentation page used a fixed 2-column grid layout that caused horizontal overflow on mobile devices.

````tsx
// apps/landing/src/app/(detail)/docs/core-concepts/nm-base/page.mdx
<div
  style={{
    display: 'grid',
    gridTemplateColumns: '1fr 1fr',  // Fixed 2 columns
    gap: '2rem',
    marginBottom: '2rem',
    alignItems: 'start',
  }}
>
````
</br>

### Solution: Implemented dedicated ExampleGrid component for MDX

**Background:**

While DevupUI's `Grid` component supports responsive arrays, it cannot be used directly in MDX files because the MDX parser (acorn) cannot parse array syntax within JSX:
```mdx
<!--  MDX parsing error -->
<Grid gridTemplateColumns={['repeat(1, 1fr)', 'repeat(2, 1fr)']}>
  <div>A</div>
  <div>B</div>
</Grid>
```

**Solution:**

Created a separate `.tsx` component to be processed by DevupUI's compiler at build time:
```tsx
// ExampleGrid.tsx - compiled at build time
export function ExampleGrid({ children }: { children: ReactNode }) {
  return (
    <Grid 
      gap="16px" 
      gridTemplateColumns={['repeat(1, 1fr)', 'repeat(2, 1fr)']}
    >
      {children}
    </Grid>
  )
}
```

**Design decisions:**
- Reuses DevupUI's `Grid` component for consistency with existing codebase
- Uses responsive array pattern following DevupUI standards
- `children: ReactNode` type for flexible number of child elements
- Server component optimized at build time

</br>


### Result

<table>
<tr>
<th>Before</th>
<th>After</th>
</tr>
<tr>
<td>

https://github.com/user-attachments/assets/a8f71561-9363-46e7-81b5-89920d5f77be

❌ Fixed 2-column grid causes horizontal overflow and content cut off  
❌ Users must scroll horizontally to view code examples

</td>
<td>

<img width="287" alt="image" src="https://github.com/user-attachments/assets/da63b969-200c-439f-97fe-adec8d2307b3" />

✅ Responsive grid: 1 column on mobile, 2 columns on desktop  
✅ All content visible and properly laid out within viewport

</td>
</tr>
</table>