### PR TITLE
Convert markdown tables to Table component in MDX files

### DIFF
--- a/apps/landing/src/app/(detail)/docs/api/group-selector/page.mdx
+++ b/apps/landing/src/app/(detail)/docs/api/group-selector/page.mdx
@@ -1,10 +1,10 @@
 import {
   Table,
-  TableHead,
   TableBody,
-  TableRow,
-  TableHeaderCell,
   TableCell,
+  TableHead,
+  TableHeaderCell,
+  TableRow,
 } from '@/components/mdx/components/Table'
 
 export const metadata = {
@@ -44,19 +44,33 @@ Add `role="group"` to a parent element, then use `_groupHover`, `_groupFocus`, o
   </TableHead>
   <TableBody>
     <TableRow>
-      <TableCell><code>_groupHover</code></TableCell>
-      <TableCell>Parent with <code>role="group"</code> is hovered</TableCell>
+      <TableCell>
+        <code>_groupHover</code>
+      </TableCell>
+      <TableCell>
+        Parent with <code>role=&quot;group&quot;</code> is hovered
+      </TableCell>
     </TableRow>
     <TableRow>
-      <TableCell><code>_groupFocus</code></TableCell>
-      <TableCell>Parent with <code>role="group"</code> is focused</TableCell>
+      <TableCell>
+        <code>_groupFocus</code>
+      </TableCell>
+      <TableCell>
+        Parent with <code>role=&quot;group&quot;</code> is focused
+      </TableCell>
     </TableRow>
     <TableRow>
-      <TableCell><code>_groupActive</code></TableCell>
-      <TableCell>Parent with <code>role="group"</code> is active (pressed)</TableCell>
+      <TableCell>
+        <code>_groupActive</code>
+      </TableCell>
+      <TableCell>
+        Parent with <code>role=&quot;group&quot;</code> is active (pressed)
+      </TableCell>
     </TableRow>
     <TableRow>
-      <TableCell><code>_groupFocusWithin</code></TableCell>
+      <TableCell>
+        <code>_groupFocusWithin</code>
+      </TableCell>
       <TableCell>Any element inside the group receives focus</TableCell>
     </TableRow>
   </TableBody>

--- a/apps/landing/src/app/(detail)/docs/devup/breakpoints/page.mdx
+++ b/apps/landing/src/app/(detail)/docs/devup/breakpoints/page.mdx
@@ -1,10 +1,10 @@
 import {
   Table,
-  TableHead,
   TableBody,
-  TableRow,
-  TableHeaderCell,
   TableCell,
+  TableHead,
+  TableHeaderCell,
+  TableRow,
 } from '@/components/mdx/components/Table'
 
 export const metadata = {
@@ -32,37 +32,49 @@ Devup UI uses a mobile-first responsive design system with 6 breakpoints. Use ar
   <TableBody>
     <TableRow>
       <TableCell>0</TableCell>
-      <TableCell><code>xs</code></TableCell>
+      <TableCell>
+        <code>xs</code>
+      </TableCell>
       <TableCell>0px - 479px</TableCell>
       <TableCell>Mobile (portrait)</TableCell>
     </TableRow>
     <TableRow>
       <TableCell>1</TableCell>
-      <TableCell><code>sm</code></TableCell>
+      <TableCell>
+        <code>sm</code>
+      </TableCell>
       <TableCell>480px - 767px</TableCell>
       <TableCell>Mobile (landscape)</TableCell>
     </TableRow>
     <TableRow>
       <TableCell>2</TableCell>
-      <TableCell><code>md</code></TableCell>
+      <TableCell>
+        <code>md</code>
+      </TableCell>
       <TableCell>768px - 991px</TableCell>
       <TableCell>Tablet</TableCell>
     </TableRow>
     <TableRow>
       <TableCell>3</TableCell>
-      <TableCell><code>lg</code></TableCell>
+      <TableCell>
+        <code>lg</code>
+      </TableCell>
       <TableCell>992px - 1279px</TableCell>
       <TableCell>Small desktop</TableCell>
     </TableRow>
     <TableRow>
       <TableCell>4</TableCell>
-      <TableCell><code>xl</code></TableCell>
+      <TableCell>
+        <code>xl</code>
+      </TableCell>
       <TableCell>1280px - 1599px</TableCell>
       <TableCell>Desktop</TableCell>
     </TableRow>
     <TableRow>
       <TableCell>5</TableCell>
-      <TableCell><code>2xl</code></TableCell>
+      <TableCell>
+        <code>2xl</code>
+      </TableCell>
       <TableCell>1600px+</TableCell>
       <TableCell>Large desktop</TableCell>
     </TableRow>

--- a/apps/landing/src/app/(detail)/docs/devup/typography/page.mdx
+++ b/apps/landing/src/app/(detail)/docs/devup/typography/page.mdx
@@ -1,10 +1,10 @@
 import {
   Table,
-  TableHead,
   TableBody,
-  TableRow,
-  TableHeaderCell,
   TableCell,
+  TableHead,
+  TableHeaderCell,
+  TableRow,
 } from '@/components/mdx/components/Table'
 
 export const metadata = {
@@ -80,39 +80,67 @@ Each typography style can include:
   </TableHead>
   <TableBody>
     <TableRow>
-      <TableCell><code>fontFamily</code></TableCell>
+      <TableCell>
+        <code>fontFamily</code>
+      </TableCell>
       <TableCell>Font family name</TableCell>
-      <TableCell><code>"Pretendard"</code></TableCell>
+      <TableCell>
+        <code>&quot;Pretendard&quot;</code>
+      </TableCell>
     </TableRow>
     <TableRow>
-      <TableCell><code>fontSize</code></TableCell>
+      <TableCell>
+        <code>fontSize</code>
+      </TableCell>
       <TableCell>Font size</TableCell>
-      <TableCell><code>"16px"</code></TableCell>
+      <TableCell>
+        <code>&quot;16px&quot;</code>
+      </TableCell>
     </TableRow>
     <TableRow>
-      <TableCell><code>fontWeight</code></TableCell>
+      <TableCell>
+        <code>fontWeight</code>
+      </TableCell>
       <TableCell>Font weight (number or string)</TableCell>
-      <TableCell><code>700</code> or <code>"bold"</code></TableCell>
+      <TableCell>
+        <code>700</code> or <code>&quot;bold&quot;</code>
+      </TableCell>
     </TableRow>
     <TableRow>
-      <TableCell><code>fontStyle</code></TableCell>
+      <TableCell>
+        <code>fontStyle</code>
+      </TableCell>
       <TableCell>Font style</TableCell>
-      <TableCell><code>"normal"</code> or <code>"italic"</code></TableCell>
+      <TableCell>
+        <code>&quot;normal&quot;</code> or <code>&quot;italic&quot;</code>
+      </TableCell>
     </TableRow>
     <TableRow>
-      <TableCell><code>lineHeight</code></TableCell>
+      <TableCell>
+        <code>lineHeight</code>
+      </TableCell>
       <TableCell>Line height (number or string)</TableCell>
-      <TableCell><code>1.5</code> or <code>"150%"</code></TableCell>
+      <TableCell>
+        <code>1.5</code> or <code>&quot;150%&quot;</code>
+      </TableCell>
     </TableRow>
     <TableRow>
-      <TableCell><code>letterSpacing</code></TableCell>
+      <TableCell>
+        <code>letterSpacing</code>
+      </TableCell>
       <TableCell>Letter spacing</TableCell>
-      <TableCell><code>"-0.02em"</code></TableCell>
+      <TableCell>
+        <code>&quot;-0.02em&quot;</code>
+      </TableCell>
     </TableRow>
     <TableRow>
-      <TableCell><code>textTransform</code></TableCell>
+      <TableCell>
+        <code>textTransform</code>
+      </TableCell>
       <TableCell>Text transformation</TableCell>
-      <TableCell><code>"uppercase"</code></TableCell>
+      <TableCell>
+        <code>&quot;uppercase&quot;</code>
+      </TableCell>
     </TableRow>
   </TableBody>
 </Table>

--- a/apps/landing/src/app/(detail)/docs/overview/page.mdx
+++ b/apps/landing/src/app/(detail)/docs/overview/page.mdx
@@ -1,10 +1,10 @@
 import {
   Table,
-  TableHead,
   TableBody,
-  TableRow,
-  TableHeaderCell,
   TableCell,
+  TableHead,
+  TableHeaderCell,
+  TableRow,
 } from '@/components/mdx/components/Table'
 
 export const metadata = {


### PR DESCRIPTION
Replace all markdown-style tables in landing MDX files with Table component to fix eslint issues. Updated files:
- docs/overview/page.mdx (2 tables)
- docs/devup/typography/page.mdx (1 table)
- docs/devup/breakpoints/page.mdx (1 table)
- docs/api/group-selector/page.mdx (1 table)