### PR TITLE
docs: update textarea component page

### DIFF
--- a/apps/landing/src/app/(detail)/components/[component]/textarea/Api.mdx
+++ b/apps/landing/src/app/(detail)/components/[component]/textarea/Api.mdx
@@ -1,3 +1,47 @@
-import { ComingSoon } from '@/components/ComingSoon'
+import { PropsTable } from '@/components/PropsTable'
 
-<ComingSoon />
+###### API
+
+`Textarea` props extends the textarea HTML attributes.
+
+<PropsTable
+  componentProps={[
+    {
+      property: 'typography',
+      description: 'Typography token applied to the textarea',
+      type: '`keyof DevupThemeTypography`',
+      default: '`undefined`',
+    },
+    {
+      property: 'error',
+      description: 'Whether the textarea is in an invalid state',
+      type: '`boolean`',
+      default: '`false`',
+    },
+    {
+      property: 'errorMessage',
+      description:
+        'Validation message shown below the textarea when `error` is true',
+      type: '`string`',
+      default: '`undefined`',
+    },
+    {
+      property: 'rows',
+      description: 'Visible text rows',
+      type: '`number`',
+      default: '`3`',
+    },
+    {
+      property: 'classNames',
+      description: 'Custom class names for inner elements',
+      type: '```{<br>  container?: string<br>  textarea?: string<br>  errorMessage?: string<br>}```',
+      default: '`undefined`',
+    },
+    {
+      property: 'colors',
+      description: 'Custom color variables for the textarea',
+      type: '```{<br>  primary?: string<br>  error?: string<br>  text?: string<br>  border?: string<br>  background?: string<br>  placeholder?: string<br>  focusRing?: string<br>}```',
+      default: '`undefined`',
+    },
+  ]}
+/>

--- a/apps/landing/src/app/(detail)/components/[component]/textarea/demo/1_Default.tsx
+++ b/apps/landing/src/app/(detail)/components/[component]/textarea/demo/1_Default.tsx
@@ -1,0 +1,9 @@
+import { Textarea } from '@devup-ui/components'
+
+/**
+ * **Default**
+ * Basic textarea for multi-line user input.
+ */
+export default function Default() {
+  return <Textarea placeholder="Enter your message..." />
+}

--- a/apps/landing/src/app/(detail)/components/[component]/textarea/demo/2_Error.tsx
+++ b/apps/landing/src/app/(detail)/components/[component]/textarea/demo/2_Error.tsx
@@ -1,0 +1,15 @@
+import { Textarea } from '@devup-ui/components'
+
+/**
+ * **Error**
+ * Use `error` and `errorMessage` to show validation feedback.
+ */
+export default function Error() {
+  return (
+    <Textarea
+      error
+      errorMessage="Please enter at least 10 characters."
+      placeholder="Describe your request..."
+    />
+  )
+}

--- a/apps/landing/src/app/(detail)/components/[component]/textarea/demo/3_Disabled.tsx
+++ b/apps/landing/src/app/(detail)/components/[component]/textarea/demo/3_Disabled.tsx
@@ -1,0 +1,15 @@
+import { Textarea } from '@devup-ui/components'
+
+/**
+ * **Disabled**
+ * Disabled textareas keep the value visible while preventing edits.
+ */
+export default function Disabled() {
+  return (
+    <Textarea
+      defaultValue="This message is read-only."
+      disabled
+      placeholder="Disabled textarea"
+    />
+  )
+}

--- a/apps/landing/src/app/(detail)/components/[component]/textarea/demo/4_Colors.tsx
+++ b/apps/landing/src/app/(detail)/components/[component]/textarea/demo/4_Colors.tsx
@@ -1,0 +1,21 @@
+import { Textarea } from '@devup-ui/components'
+
+/**
+ * **Colors**
+ * Override the component color variables to match a custom theme.
+ */
+export default function Colors() {
+  return (
+    <Textarea
+      colors={{
+        primary: '#2563EB',
+        border: '#BFDBFE',
+        background: '#EFF6FF',
+        placeholder: '#60A5FA',
+        focusRing: 'rgba(37, 99, 235, 0.18)',
+      }}
+      placeholder="Custom themed textarea"
+      rows={4}
+    />
+  )
+}

--- a/apps/landing/src/app/(detail)/components/[component]/textarea/index.mdx
+++ b/apps/landing/src/app/(detail)/components/[component]/textarea/index.mdx
@@ -1,1 +1,1 @@
-`Textarea` component is used for multi-line text input.
+`Textarea` component is used for multi-line text input, such as messages, comments, and descriptions.


### PR DESCRIPTION
## Summary
- Add Textarea landing demos for default, error, disabled, and custom color states.
- Replace the Textarea API placeholder with a props table based on the current component props.
- Expand the component intro sentence to clarify common multi-line input use cases.

## Related Issue
- Closes #560

## Tests
- `bun x eslint apps/landing/src/app/(detail)/components/[component]/textarea/Api.mdx apps/landing/src/app/(detail)/components/[component]/textarea/index.mdx apps/landing/src/app/(detail)/components/[component]/textarea/demo/1_Default.tsx apps/landing/src/app/(detail)/components/[component]/textarea/demo/2_Error.tsx apps/landing/src/app/(detail)/components/[component]/textarea/demo/3_Disabled.tsx apps/landing/src/app/(detail)/components/[component]/textarea/demo/4_Colors.tsx`
- `bun run --filter landing lint`
- `bun run build`
- Pre-commit lint/Rust coverage portion: passed through `cargo fmt --all -- --check`, `cargo clippy --all-targets --all-features -- -D warnings`, `eslint`, and `cargo tarpaulin --out xml --out stdout --all-targets --engine llvm` with 97.75% coverage.

## Notes
- `bun run build:landing` is currently blocked locally before the page is loaded by `packages/next-plugin/dist/index.cjs` raising `ReferenceError: t is not defined` from the generated build output.
- The full pre-commit `bun test` step is also blocked locally by generated `packages/plugin-utils/dist/index.mjs` exports such as `u` not being declared. The changed Textarea docs and demos pass the targeted landing lint checks above.
