### PR TITLE
docs: add Webpack and Bun setup guides

### DIFF
--- a/apps/landing/src/app/(detail)/docs/installation/page.mdx
+++ b/apps/landing/src/app/(detail)/docs/installation/page.mdx
@@ -94,6 +94,47 @@ export default defineConfig({
 })
 ```
 
+### Using Devup UI with Webpack
+
+If you are using Webpack directly, you can install the Webpack plugin.
+
+```bash
+npm install @devup-ui/webpack-plugin
+```
+
+Add the plugin to your Webpack configuration.
+
+```js
+// webpack.config.js
+
+import { DevupUIWebpackPlugin } from '@devup-ui/webpack-plugin'
+
+export default {
+  plugins: [new DevupUIWebpackPlugin()],
+}
+```
+
+### Using Devup UI with Bun
+
+If you are using Bun as the bundler, install the Bun plugin with Devup UI.
+
+```bash
+bun add @devup-ui/react @devup-ui/bun-plugin
+```
+
+Import the plugin before running your Bun build so it can register itself with Bun.
+
+```ts
+// build.ts
+
+import '@devup-ui/bun-plugin'
+
+await Bun.build({
+  entrypoints: ['./src/index.tsx'],
+  outdir: './dist',
+})
+```
+
 ## Project Examples
 
 - [Next.js Example](https://github.com/dev-five-git/devup-ui/tree/main/apps/next)

--- a/apps/landing/src/app/(detail)/docs/quick-start/page.mdx
+++ b/apps/landing/src/app/(detail)/docs/quick-start/page.mdx
@@ -19,6 +19,10 @@ npm install @devup-ui/react
 npm install @devup-ui/vite-plugin    # for Vite
 npm install @devup-ui/next-plugin    # for Next.js
 npm install @devup-ui/rsbuild-plugin # for Rsbuild
+npm install @devup-ui/webpack-plugin # for Webpack
+
+# Or use the Bun plugin in Bun projects
+bun add @devup-ui/react @devup-ui/bun-plugin
 ```
 
 ## 2. Configure Your Build Tool
@@ -57,6 +61,29 @@ import { pluginReact } from '@rsbuild/plugin-react'
 
 export default defineConfig({
   plugins: [pluginReact(), DevupUIRsbuildPlugin()],
+})
+```
+
+### Webpack
+
+```js
+// webpack.config.js
+import { DevupUIWebpackPlugin } from '@devup-ui/webpack-plugin'
+
+export default {
+  plugins: [new DevupUIWebpackPlugin()],
+}
+```
+
+### Bun
+
+```ts
+// build.ts
+import '@devup-ui/bun-plugin'
+
+await Bun.build({
+  entrypoints: ['./src/index.tsx'],
+  outdir: './dist',
 })
 ```
 


### PR DESCRIPTION
## Summary

- Add Webpack setup instructions to the installation and quick-start docs
- Add Bun setup instructions using the Bun plugin's side-effect registration path
- Keep the examples focused on the existing public plugin packages

## Tests

- `bun x eslint apps/landing/src/app/(detail)/docs/installation/page.mdx apps/landing/src/app/(detail)/docs/quick-start/page.mdx`
- `bun run --filter landing lint`