### PR TITLE
Merge devup css into shared chunks on Vite 8 (Rolldown)

### DIFF
--- a/.changepacks/changepack_log_69ML5o7urZp4l6prVocVq.json
+++ b/.changepacks/changepack_log_69ML5o7urZp4l6prVocVq.json
@@ -1,0 +1,7 @@
+{
+  "changes": {
+    "packages/vite-plugin/package.json": "Patch"
+  },
+  "note": "Merge devup css into shared chunks on Vite 8 (Rolldown)",
+  "date": "2026-08-22T12:03:08.578984400Z"
+}

--- a/.changepacks/changepack_log_Kq7mXvR2taWpL9dcE4hNs.json
+++ b/.changepacks/changepack_log_Kq7mXvR2taWpL9dcE4hNs.json
@@ -1,0 +1,7 @@
+{
+  "changes": {
+    "packages/vite-plugin/package.json": "Patch"
+  },
+  "note": "Fix vite plugin cold-start build, css determinism, and manualChunks merge",
+  "date": "2026-08-23T04:15:00.000000000Z"
+}

--- a/benchmark/vinext-devup-ui/app/components/Section01.tsx
+++ b/benchmark/vinext-devup-ui/app/components/Section01.tsx
@@ -1,0 +1,71 @@
+import { Box, Center, Flex, Text } from '@devup-ui/react'
+
+/**
+ * Shared section 01. Imported by an overlapping subset of the routes, so its
+ * atoms must land in one shared CSS chunk instead of being copied into every
+ * route chunk that uses it.
+ */
+export function Section01() {
+  return (
+    <Flex
+      alignItems="stretch"
+      bg="#ffffff"
+      border="1px solid #84cc16"
+      borderRadius={9}
+      boxShadow="0 1px 2px rgba(0,0,0,0.08)"
+      flexDirection="column"
+      gap={9}
+      p={17}
+      w="100%"
+    >
+      <Flex alignItems="center" gap={7} justifyContent="space-between" w="100%">
+        <Text color="#84cc16" fontSize={17} fontWeight={700} lineHeight={1.3}>
+          Section 01
+        </Text>
+        <Box
+          bg="#3b82f6"
+          borderRadius={999}
+          color="#ffffff"
+          fontSize={11}
+          fontWeight={600}
+          px={9}
+          py={4}
+        >
+          Tag 01
+        </Box>
+      </Flex>
+      <Box bg="#3b82f6" h={2} w="100%" />
+      <Text color="#4b5563" fontSize={13} lineHeight={1.6}>
+        Shared section 01 body copy.
+      </Text>
+      <Flex flexWrap="wrap" gap={5} mt={3} w="100%">
+        <Center
+          _hover={{ bg: '#84cc16' }}
+          bg="#f9fafb"
+          borderRadius={5}
+          color="#84cc16"
+          cursor="pointer"
+          flex={1}
+          fontSize={12}
+          px={11}
+          py={9}
+        >
+          Primary 01
+        </Center>
+        <Center
+          _hover={{ opacity: 0.1 }}
+          bg="#3b82f6"
+          borderRadius={5}
+          color="#ffffff"
+          cursor="pointer"
+          flex={1}
+          fontSize={12}
+          px={11}
+          py={9}
+        >
+          Secondary 01
+        </Center>
+      </Flex>
+    </Flex>
+  )
+}

--- a/benchmark/vinext-devup-ui/app/components/Section02.tsx
+++ b/benchmark/vinext-devup-ui/app/components/Section02.tsx
@@ -1,0 +1,71 @@
+import { Box, Center, Flex, Text } from '@devup-ui/react'
+
+/**
+ * Shared section 02. Imported by an overlapping subset of the routes, so its
+ * atoms must land in one shared CSS chunk instead of being copied into every
+ * route chunk that uses it.
+ */
+export function Section02() {
+  return (
+    <Flex
+      alignItems="stretch"
+      bg="#ffffff"
+      border="1px solid #06b6d4"
+      borderRadius={10}
+      boxShadow="0 2px 4px rgba(0,0,0,0.08)"
+      flexDirection="column"
+      gap={10}
+      p={18}
+      w="100%"
+    >
+      <Flex alignItems="center" gap={8} justifyContent="space-between" w="100%">
+        <Text color="#06b6d4" fontSize={18} fontWeight={700} lineHeight={1.3}>
+          Section 02
+        </Text>
+        <Box
+          bg="#ef4444"
+          borderRadius={999}
+          color="#ffffff"
+          fontSize={12}
+          fontWeight={600}
+          px={10}
+          py={5}
+        >
+          Tag 02
+        </Box>
+      </Flex>
+      <Box bg="#ef4444" h={3} w="100%" />
+      <Text color="#4b5563" fontSize={14} lineHeight={1.6}>
+        Shared section 02 body copy.
+      </Text>
+      <Flex flexWrap="wrap" gap={6} mt={4} w="100%">
+        <Center
+          _hover={{ bg: '#06b6d4' }}
+          bg="#f9fafb"
+          borderRadius={6}
+          color="#06b6d4"
+          cursor="pointer"
+          flex={1}
+          fontSize={13}
+          px={12}
+          py={10}
+        >
+          Primary 02
+        </Center>
+        <Center
+          _hover={{ opacity: 0.2 }}
+          bg="#ef4444"
+          borderRadius={6}
+          color="#ffffff"
+          cursor="pointer"
+          flex={1}
+          fontSize={13}
+          px={12}
+          py={10}
+        >
+          Secondary 02
+        </Center>
+      </Flex>
+    </Flex>
+  )
+}

--- a/benchmark/vinext-devup-ui/app/components/Section03.tsx
+++ b/benchmark/vinext-devup-ui/app/components/Section03.tsx
@@ -1,0 +1,71 @@
+import { Box, Center, Flex, Text } from '@devup-ui/react'
+
+/**
+ * Shared section 03. Imported by an overlapping subset of the routes, so its
+ * atoms must land in one shared CSS chunk instead of being copied into every
+ * route chunk that uses it.
+ */
+export function Section03() {
+  return (
+    <Flex
+      alignItems="stretch"
+      bg="#ffffff"
+      border="1px solid #8b5cf6"
+      borderRadius={11}
+      boxShadow="0 3px 6px rgba(0,0,0,0.08)"
+      flexDirection="column"
+      gap={11}
+      p={19}
+      w="100%"
+    >
+      <Flex alignItems="center" gap={9} justifyContent="space-between" w="100%">
+        <Text color="#8b5cf6" fontSize={19} fontWeight={700} lineHeight={1.3}>
+          Section 03
+        </Text>
+        <Box
+          bg="#14b8a6"
+          borderRadius={999}
+          color="#ffffff"
+          fontSize={13}
+          fontWeight={600}
+          px={11}
+          py={6}
+        >
+          Tag 03
+        </Box>
+      </Flex>
+      <Box bg="#14b8a6" h={1} w="100%" />
+      <Text color="#4b5563" fontSize={15} lineHeight={1.6}>
+        Shared section 03 body copy.
+      </Text>
+      <Flex flexWrap="wrap" gap={7} mt={5} w="100%">
+        <Center
+          _hover={{ bg: '#8b5cf6' }}
+          bg="#f9fafb"
+          borderRadius={7}
+          color="#8b5cf6"
+          cursor="pointer"
+          flex={1}
+          fontSize={14}
+          px={13}
+          py={11}
+        >
+          Primary 03
+        </Center>
+        <Center
+          _hover={{ opacity: 0.3 }}
+          bg="#14b8a6"
+          borderRadius={7}
+          color="#ffffff"
+          cursor="pointer"
+          flex={1}
+          fontSize={14}
+          px={13}
+          py={11}
+        >
+          Secondary 03
+        </Center>
+      </Flex>
+    </Flex>
+  )
+}

--- a/benchmark/vinext-devup-ui/app/components/Section04.tsx
+++ b/benchmark/vinext-devup-ui/app/components/Section04.tsx
@@ -1,0 +1,76 @@
+import { Box, Center, Flex, Text } from '@devup-ui/react'
+
+/**
+ * Shared section 04. Imported by an overlapping subset of the routes, so its
+ * atoms must land in one shared CSS chunk instead of being copied into every
+ * route chunk that uses it.
+ */
+export function Section04() {
+  return (
+    <Flex
+      alignItems="stretch"
+      bg="#ffffff"
+      border="1px solid #ef4444"
+      borderRadius={12}
+      boxShadow="0 4px 8px rgba(0,0,0,0.08)"
+      flexDirection="column"
+      gap={12}
+      p={20}
+      w="100%"
+    >
+      <Flex
+        alignItems="center"
+        gap={10}
+        justifyContent="space-between"
+        w="100%"
+      >
+        <Text color="#ef4444" fontSize={20} fontWeight={700} lineHeight={1.3}>
+          Section 04
+        </Text>
+        <Box
+          bg="#d946ef"
+          borderRadius={999}
+          color="#ffffff"
+          fontSize={14}
+          fontWeight={600}
+          px={12}
+          py={7}
+        >
+          Tag 04
+        </Box>
+      </Flex>
+      <Box bg="#d946ef" h={2} w="100%" />
+      <Text color="#4b5563" fontSize={16} lineHeight={1.6}>
+        Shared section 04 body copy.
+      </Text>
+      <Flex flexWrap="wrap" gap={8} mt={6} w="100%">
+        <Center
+          _hover={{ bg: '#ef4444' }}
+          bg="#f9fafb"
+          borderRadius={8}
+          color="#ef4444"
+          cursor="pointer"
+          flex={1}
+          fontSize={15}
+          px={14}
+          py={12}
+        >
+          Primary 04
+        </Center>
+        <Center
+          _hover={{ opacity: 0.4 }}
+          bg="#d946ef"
+          borderRadius={8}
+          color="#ffffff"
+          cursor="pointer"
+          flex={1}
+          fontSize={15}
+          px={14}
+          py={12}
+        >
+          Secondary 04
+        </Center>
+      </Flex>
+    </Flex>
+  )
+}

--- a/benchmark/vinext-devup-ui/app/components/Section05.tsx
+++ b/benchmark/vinext-devup-ui/app/components/Section05.tsx
@@ -1,0 +1,76 @@
+import { Box, Center, Flex, Text } from '@devup-ui/react'
+
+/**
+ * Shared section 05. Imported by an overlapping subset of the routes, so its
+ * atoms must land in one shared CSS chunk instead of being copied into every
+ * route chunk that uses it.
+ */
+export function Section05() {
+  return (
+    <Flex
+      alignItems="stretch"
+      bg="#ffffff"
+      border="1px solid #84cc16"
+      borderRadius={13}
+      boxShadow="0 5px 10px rgba(0,0,0,0.08)"
+      flexDirection="column"
+      gap={13}
+      p={21}
+      w="100%"
+    >
+      <Flex
+        alignItems="center"
+        gap={11}
+        justifyContent="space-between"
+        w="100%"
+      >
+        <Text color="#84cc16" fontSize={21} fontWeight={700} lineHeight={1.3}>
+          Section 05
+        </Text>
+        <Box
+          bg="#84cc16"
+          borderRadius={999}
+          color="#ffffff"
+          fontSize={15}
+          fontWeight={600}
+          px={13}
+          py={8}
+        >
+          Tag 05
+        </Box>
+      </Flex>
+      <Box bg="#84cc16" h={3} w="100%" />
+      <Text color="#4b5563" fontSize={17} lineHeight={1.6}>
+        Shared section 05 body copy.
+      </Text>
+      <Flex flexWrap="wrap" gap={9} mt={7} w="100%">
+        <Center
+          _hover={{ bg: '#84cc16' }}
+          bg="#f9fafb"
+          borderRadius={9}
+          color="#84cc16"
+          cursor="pointer"
+          flex={1}
+          fontSize={16}
+          px={15}
+          py={13}
+        >
+          Primary 05
+        </Center>
+        <Center
+          _hover={{ opacity: 0.5 }}
+          bg="#84cc16"
+          borderRadius={9}
+          color="#ffffff"
+          cursor="pointer"
+          flex={1}
+          fontSize={16}
+          px={15}
+          py={13}
+        >
+          Secondary 05
+        </Center>
+      </Flex>
+    </Flex>
+  )
+}

--- a/benchmark/vinext-devup-ui/app/components/Section06.tsx
+++ b/benchmark/vinext-devup-ui/app/components/Section06.tsx
@@ -1,0 +1,76 @@
+import { Box, Center, Flex, Text } from '@devup-ui/react'
+
+/**
+ * Shared section 06. Imported by an overlapping subset of the routes, so its
+ * atoms must land in one shared CSS chunk instead of being copied into every
+ * route chunk that uses it.
+ */
+export function Section06() {
+  return (
+    <Flex
+      alignItems="stretch"
+      bg="#ffffff"
+      border="1px solid #06b6d4"
+      borderRadius={14}
+      boxShadow="0 6px 12px rgba(0,0,0,0.08)"
+      flexDirection="column"
+      gap={14}
+      p={22}
+      w="100%"
+    >
+      <Flex
+        alignItems="center"
+        gap={12}
+        justifyContent="space-between"
+        w="100%"
+      >
+        <Text color="#06b6d4" fontSize={22} fontWeight={700} lineHeight={1.3}>
+          Section 06
+        </Text>
+        <Box
+          bg="#6366f1"
+          borderRadius={999}
+          color="#ffffff"
+          fontSize={16}
+          fontWeight={600}
+          px={14}
+          py={9}
+        >
+          Tag 06
+        </Box>
+      </Flex>
+      <Box bg="#6366f1" h={1} w="100%" />
+      <Text color="#4b5563" fontSize={18} lineHeight={1.6}>
+        Shared section 06 body copy.
+      </Text>
+      <Flex flexWrap="wrap" gap={10} mt={8} w="100%">
+        <Center
+          _hover={{ bg: '#06b6d4' }}
+          bg="#f9fafb"
+          borderRadius={10}
+          color="#06b6d4"
+          cursor="pointer"
+          flex={1}
+          fontSize={17}
+          px={16}
+          py={14}
+        >
+          Primary 06
+        </Center>
+        <Center
+          _hover={{ opacity: 0.6 }}
+          bg="#6366f1"
+          borderRadius={10}
+          color="#ffffff"
+          cursor="pointer"
+          flex={1}
+          fontSize={17}
+          px={16}
+          py={14}
+        >
+          Secondary 06
+        </Center>
+      </Flex>
+    </Flex>
+  )
+}

--- a/benchmark/vinext-devup-ui/app/components/Section07.tsx
+++ b/benchmark/vinext-devup-ui/app/components/Section07.tsx
@@ -1,0 +1,76 @@
+import { Box, Center, Flex, Text } from '@devup-ui/react'
+
+/**
+ * Shared section 07. Imported by an overlapping subset of the routes, so its
+ * atoms must land in one shared CSS chunk instead of being copied into every
+ * route chunk that uses it.
+ */
+export function Section07() {
+  return (
+    <Flex
+      alignItems="stretch"
+      bg="#ffffff"
+      border="1px solid #8b5cf6"
+      borderRadius={15}
+      boxShadow="0 7px 14px rgba(0,0,0,0.08)"
+      flexDirection="column"
+      gap={15}
+      p={23}
+      w="100%"
+    >
+      <Flex
+        alignItems="center"
+        gap={13}
+        justifyContent="space-between"
+        w="100%"
+      >
+        <Text color="#8b5cf6" fontSize={23} fontWeight={700} lineHeight={1.3}>
+          Section 07
+        </Text>
+        <Box
+          bg="#f97316"
+          borderRadius={999}
+          color="#ffffff"
+          fontSize={17}
+          fontWeight={600}
+          px={15}
+          py={10}
+        >
+          Tag 07
+        </Box>
+      </Flex>
+      <Box bg="#f97316" h={2} w="100%" />
+      <Text color="#4b5563" fontSize={19} lineHeight={1.6}>
+        Shared section 07 body copy.
+      </Text>
+      <Flex flexWrap="wrap" gap={11} mt={9} w="100%">
+        <Center
+          _hover={{ bg: '#8b5cf6' }}
+          bg="#f9fafb"
+          borderRadius={11}
+          color="#8b5cf6"
+          cursor="pointer"
+          flex={1}
+          fontSize={18}
+          px={17}
+          py={15}
+        >
+          Primary 07
+        </Center>
+        <Center
+          _hover={{ opacity: 0.7 }}
+          bg="#f97316"
+          borderRadius={11}
+          color="#ffffff"
+          cursor="pointer"
+          flex={1}
+          fontSize={18}
+          px={17}
+          py={15}
+        >
+          Secondary 07
+        </Center>
+      </Flex>
+    </Flex>
+  )
+}

--- a/benchmark/vinext-devup-ui/app/components/Section08.tsx
+++ b/benchmark/vinext-devup-ui/app/components/Section08.tsx
@@ -1,0 +1,76 @@
+import { Box, Center, Flex, Text } from '@devup-ui/react'
+
+/**
+ * Shared section 08. Imported by an overlapping subset of the routes, so its
+ * atoms must land in one shared CSS chunk instead of being copied into every
+ * route chunk that uses it.
+ */
+export function Section08() {
+  return (
+    <Flex
+      alignItems="stretch"
+      bg="#ffffff"
+      border="1px solid #ef4444"
+      borderRadius={16}
+      boxShadow="0 8px 16px rgba(0,0,0,0.08)"
+      flexDirection="column"
+      gap={16}
+      p={24}
+      w="100%"
+    >
+      <Flex
+        alignItems="center"
+        gap={14}
+        justifyContent="space-between"
+        w="100%"
+      >
+        <Text color="#ef4444" fontSize={24} fontWeight={700} lineHeight={1.3}>
+          Section 08
+        </Text>
+        <Box
+          bg="#06b6d4"
+          borderRadius={999}
+          color="#ffffff"
+          fontSize={18}
+          fontWeight={600}
+          px={16}
+          py={11}
+        >
+          Tag 08
+        </Box>
+      </Flex>
+      <Box bg="#06b6d4" h={3} w="100%" />
+      <Text color="#4b5563" fontSize={20} lineHeight={1.6}>
+        Shared section 08 body copy.
+      </Text>
+      <Flex flexWrap="wrap" gap={12} mt={10} w="100%">
+        <Center
+          _hover={{ bg: '#ef4444' }}
+          bg="#f9fafb"
+          borderRadius={12}
+          color="#ef4444"
+          cursor="pointer"
+          flex={1}
+          fontSize={19}
+          px={18}
+          py={16}
+        >
+          Primary 08
+        </Center>
+        <Center
+          _hover={{ opacity: 0.8 }}
+          bg="#06b6d4"
+          borderRadius={12}
+          color="#ffffff"
+          cursor="pointer"
+          flex={1}
+          fontSize={19}
+          px={18}
+          py={16}
+        >
+          Secondary 08
+        </Center>
+      </Flex>
+    </Flex>
+  )
+}

--- a/benchmark/vinext-devup-ui/app/r01/page.tsx
+++ b/benchmark/vinext-devup-ui/app/r01/page.tsx
@@ -1,0 +1,34 @@
+'use client'
+
+import { Box, Flex, Text } from '@devup-ui/react'
+
+import { Section01 } from '../components/Section01'
+import { Section02 } from '../components/Section02'
+import { Section04 } from '../components/Section04'
+import { Section07 } from '../components/Section07'
+
+export default function Route01Page() {
+  return (
+    <Box bg="#f8fafc" minH="100vh" px={17} py={21}>
+      <Flex flexDirection="column" gap={13} w="100%">
+        <Text color="#ef4444" fontSize={19} fontWeight={510}>
+          Route 01
+        </Text>
+        <Box
+          bg="#14b8a6"
+          borderRadius={7}
+          color="#ffffff"
+          fontSize={13}
+          px={11}
+          py={5}
+        >
+          Route 01 badge
+        </Box>
+        <Section01 />
+        <Section02 />
+        <Section04 />
+        <Section07 />
+      </Flex>
+    </Box>
+  )
+}

--- a/benchmark/vinext-devup-ui/app/r02/page.tsx
+++ b/benchmark/vinext-devup-ui/app/r02/page.tsx
@@ -1,0 +1,34 @@
+'use client'
+
+import { Box, Flex, Text } from '@devup-ui/react'
+
+import { Section02 } from '../components/Section02'
+import { Section03 } from '../components/Section03'
+import { Section05 } from '../components/Section05'
+import { Section08 } from '../components/Section08'
+
+export default function Route02Page() {
+  return (
+    <Box bg="#f8fafc" minH="100vh" px={18} py={22}>
+      <Flex flexDirection="column" gap={14} w="100%">
+        <Text color="#f97316" fontSize={20} fontWeight={520}>
+          Route 02
+        </Text>
+        <Box
+          bg="#06b6d4"
+          borderRadius={8}
+          color="#ffffff"
+          fontSize={14}
+          px={12}
+          py={6}
+        >
+          Route 02 badge
+        </Box>
+        <Section02 />
+        <Section03 />
+        <Section05 />
+        <Section08 />
+      </Flex>
+    </Box>
+  )
+}

--- a/benchmark/vinext-devup-ui/app/r03/page.tsx
+++ b/benchmark/vinext-devup-ui/app/r03/page.tsx
@@ -1,0 +1,34 @@
+'use client'
+
+import { Box, Flex, Text } from '@devup-ui/react'
+
+import { Section01 } from '../components/Section01'
+import { Section03 } from '../components/Section03'
+import { Section04 } from '../components/Section04'
+import { Section06 } from '../components/Section06'
+
+export default function Route03Page() {
+  return (
+    <Box bg="#f8fafc" minH="100vh" px={19} py={23}>
+      <Flex flexDirection="column" gap={15} w="100%">
+        <Text color="#f59e0b" fontSize={21} fontWeight={530}>
+          Route 03
+        </Text>
+        <Box
+          bg="#3b82f6"
+          borderRadius={9}
+          color="#ffffff"
+          fontSize={15}
+          px={13}
+          py={7}
+        >
+          Route 03 badge
+        </Box>
+        <Section01 />
+        <Section03 />
+        <Section04 />
+        <Section06 />
+      </Flex>
+    </Box>
+  )
+}

--- a/benchmark/vinext-devup-ui/app/r04/page.tsx
+++ b/benchmark/vinext-devup-ui/app/r04/page.tsx
@@ -1,0 +1,34 @@
+'use client'
+
+import { Box, Flex, Text } from '@devup-ui/react'
+
+import { Section02 } from '../components/Section02'
+import { Section04 } from '../components/Section04'
+import { Section05 } from '../components/Section05'
+import { Section07 } from '../components/Section07'
+
+export default function Route04Page() {
+  return (
+    <Box bg="#f8fafc" minH="100vh" px={20} py={24}>
+      <Flex flexDirection="column" gap={16} w="100%">
+        <Text color="#84cc16" fontSize={22} fontWeight={540}>
+          Route 04
+        </Text>
+        <Box
+          bg="#6366f1"
+          borderRadius={10}
+          color="#ffffff"
+          fontSize={16}
+          px={14}
+          py={8}
+        >
+          Route 04 badge
+        </Box>
+        <Section02 />
+        <Section04 />
+        <Section05 />
+        <Section07 />
+      </Flex>
+    </Box>
+  )
+}

--- a/benchmark/vinext-devup-ui/app/r05/page.tsx
+++ b/benchmark/vinext-devup-ui/app/r05/page.tsx
@@ -1,0 +1,34 @@
+'use client'
+
+import { Box, Flex, Text } from '@devup-ui/react'
+
+import { Section03 } from '../components/Section03'
+import { Section05 } from '../components/Section05'
+import { Section06 } from '../components/Section06'
+import { Section08 } from '../components/Section08'
+
+export default function Route05Page() {
+  return (
+    <Box bg="#f8fafc" minH="100vh" px={21} py={25}>
+      <Flex flexDirection="column" gap={17} w="100%">
+        <Text color="#22c55e" fontSize={23} fontWeight={550}>
+          Route 05
+        </Text>
+        <Box
+          bg="#8b5cf6"
+          borderRadius={11}
+          color="#ffffff"
+          fontSize={17}
+          px={15}
+          py={9}
+        >
+          Route 05 badge
+        </Box>
+        <Section03 />
+        <Section05 />
+        <Section06 />
+        <Section08 />
+      </Flex>
+    </Box>
+  )
+}

--- a/benchmark/vinext-devup-ui/app/r06/page.tsx
+++ b/benchmark/vinext-devup-ui/app/r06/page.tsx
@@ -1,0 +1,34 @@
+'use client'
+
+import { Box, Flex, Text } from '@devup-ui/react'
+
+import { Section01 } from '../components/Section01'
+import { Section04 } from '../components/Section04'
+import { Section06 } from '../components/Section06'
+import { Section07 } from '../components/Section07'
+
+export default function Route06Page() {
+  return (
+    <Box bg="#f8fafc" minH="100vh" px={22} py={26}>
+      <Flex flexDirection="column" gap={18} w="100%">
+        <Text color="#14b8a6" fontSize={24} fontWeight={560}>
+          Route 06
+        </Text>
+        <Box
+          bg="#d946ef"
+          borderRadius={12}
+          color="#ffffff"
+          fontSize={18}
+          px={16}
+          py={10}
+        >
+          Route 06 badge
+        </Box>
+        <Section01 />
+        <Section04 />
+        <Section06 />
+        <Section07 />
+      </Flex>
+    </Box>
+  )
+}

--- a/benchmark/vinext-devup-ui/app/r07/page.tsx
+++ b/benchmark/vinext-devup-ui/app/r07/page.tsx
@@ -1,0 +1,34 @@
+'use client'
+
+import { Box, Flex, Text } from '@devup-ui/react'
+
+import { Section02 } from '../components/Section02'
+import { Section05 } from '../components/Section05'
+import { Section07 } from '../components/Section07'
+import { Section08 } from '../components/Section08'
+
+export default function Route07Page() {
+  return (
+    <Box bg="#f8fafc" minH="100vh" px={23} py={27}>
+      <Flex flexDirection="column" gap={19} w="100%">
+        <Text color="#06b6d4" fontSize={25} fontWeight={570}>
+          Route 07
+        </Text>
+        <Box
+          bg="#ec4899"
+          borderRadius={13}
+          color="#ffffff"
+          fontSize={19}
+          px={17}
+          py={11}
+        >
+          Route 07 badge
+        </Box>
+        <Section02 />
+        <Section05 />
+        <Section07 />
+        <Section08 />
+      </Flex>
+    </Box>
+  )
+}

--- a/benchmark/vinext-devup-ui/app/r08/page.tsx
+++ b/benchmark/vinext-devup-ui/app/r08/page.tsx
@@ -1,0 +1,34 @@
+'use client'
+
+import { Box, Flex, Text } from '@devup-ui/react'
+
+import { Section01 } from '../components/Section01'
+import { Section03 } from '../components/Section03'
+import { Section06 } from '../components/Section06'
+import { Section08 } from '../components/Section08'
+
+export default function Route08Page() {
+  return (
+    <Box bg="#f8fafc" minH="100vh" px={24} py={28}>
+      <Flex flexDirection="column" gap={20} w="100%">
+        <Text color="#3b82f6" fontSize={26} fontWeight={580}>
+          Route 08
+        </Text>
+        <Box
+          bg="#ef4444"
+          borderRadius={14}
+          color="#ffffff"
+          fontSize={20}
+          px={18}
+          py={12}
+        >
+          Route 08 badge
+        </Box>
+        <Section01 />
+        <Section03 />
+        <Section06 />
+        <Section08 />
+      </Flex>
+    </Box>
+  )
+}

--- a/benchmark/vinext-devup-ui/app/r09/page.tsx
+++ b/benchmark/vinext-devup-ui/app/r09/page.tsx
@@ -1,0 +1,34 @@
+'use client'
+
+import { Box, Flex, Text } from '@devup-ui/react'
+
+import { Section01 } from '../components/Section01'
+import { Section02 } from '../components/Section02'
+import { Section04 } from '../components/Section04'
+import { Section07 } from '../components/Section07'
+
+export default function Route09Page() {
+  return (
+    <Box bg="#f8fafc" minH="100vh" px={25} py={29}>
+      <Flex flexDirection="column" gap={21} w="100%">
+        <Text color="#6366f1" fontSize={27} fontWeight={590}>
+          Route 09
+        </Text>
+        <Box
+          bg="#f97316"
+          borderRadius={15}
+          color="#ffffff"
+          fontSize={21}
+          px={19}
+          py={13}
+        >
+          Route 09 badge
+        </Box>
+        <Section01 />
+        <Section02 />
+        <Section04 />
+        <Section07 />
+      </Flex>
+    </Box>
+  )
+}

--- a/benchmark/vinext-devup-ui/app/r10/page.tsx
+++ b/benchmark/vinext-devup-ui/app/r10/page.tsx
@@ -1,0 +1,34 @@
+'use client'
+
+import { Box, Flex, Text } from '@devup-ui/react'
+
+import { Section02 } from '../components/Section02'
+import { Section03 } from '../components/Section03'
+import { Section05 } from '../components/Section05'
+import { Section08 } from '../components/Section08'
+
+export default function Route10Page() {
+  return (
+    <Box bg="#f8fafc" minH="100vh" px={26} py={30}>
+      <Flex flexDirection="column" gap={22} w="100%">
+        <Text color="#8b5cf6" fontSize={28} fontWeight={600}>
+          Route 10
+        </Text>
+        <Box
+          bg="#f59e0b"
+          borderRadius={16}
+          color="#ffffff"
+          fontSize={22}
+          px={20}
+          py={14}
+        >
+          Route 10 badge
+        </Box>
+        <Section02 />
+        <Section03 />
+        <Section05 />
+        <Section08 />
+      </Flex>
+    </Box>
+  )
+}

--- a/benchmark/vinext-devup-ui/app/r11/page.tsx
+++ b/benchmark/vinext-devup-ui/app/r11/page.tsx
@@ -1,0 +1,34 @@
+'use client'
+
+import { Box, Flex, Text } from '@devup-ui/react'
+
+import { Section01 } from '../components/Section01'
+import { Section03 } from '../components/Section03'
+import { Section04 } from '../components/Section04'
+import { Section06 } from '../components/Section06'
+
+export default function Route11Page() {
+  return (
+    <Box bg="#f8fafc" minH="100vh" px={27} py={31}>
+      <Flex flexDirection="column" gap={23} w="100%">
+        <Text color="#d946ef" fontSize={29} fontWeight={610}>
+          Route 11
+        </Text>
+        <Box
+          bg="#84cc16"
+          borderRadius={17}
+          color="#ffffff"
+          fontSize={23}
+          px={21}
+          py={15}
+        >
+          Route 11 badge
+        </Box>
+        <Section01 />
+        <Section03 />
+        <Section04 />
+        <Section06 />
+      </Flex>
+    </Box>
+  )
+}

--- a/benchmark/vinext-devup-ui/app/r12/page.tsx
+++ b/benchmark/vinext-devup-ui/app/r12/page.tsx
@@ -1,0 +1,34 @@
+'use client'
+
+import { Box, Flex, Text } from '@devup-ui/react'
+
+import { Section02 } from '../components/Section02'
+import { Section04 } from '../components/Section04'
+import { Section05 } from '../components/Section05'
+import { Section07 } from '../components/Section07'
+
+export default function Route12Page() {
+  return (
+    <Box bg="#f8fafc" minH="100vh" px={28} py={32}>
+      <Flex flexDirection="column" gap={24} w="100%">
+        <Text color="#ec4899" fontSize={30} fontWeight={620}>
+          Route 12
+        </Text>
+        <Box
+          bg="#22c55e"
+          borderRadius={18}
+          color="#ffffff"
+          fontSize={24}
+          px={22}
+          py={16}
+        >
+          Route 12 badge
+        </Box>
+        <Section02 />
+        <Section04 />
+        <Section05 />
+        <Section07 />
+      </Flex>
+    </Box>
+  )
+}

--- a/packages/vite-plugin/src/__tests__/plugin.test.ts
+++ b/packages/vite-plugin/src/__tests__/plugin.test.ts
@@ -246,6 +246,9 @@ describe('devupUIVitePlugin', () => {
       'other.css',
       'devup-ui.js',
       'my-devup-ui-styles.css',
+      'my-devup-ui.css',
+      'vendor-devup-ui.css',
+      'vendor-devup-ui-3.css',
       join('/p', 'src', 'app.tsx'),
     ]
 
@@ -421,6 +424,7 @@ describe('devupUIVitePlugin', () => {
       const bundle = {
         'base.css': { source: 'stale', name: 'devup-ui.css' },
         'three.css': { source: 'stale', name: 'devup-ui-3.css' },
+        'nested.css': { source: 'stale', name: 'assets/devup-ui-4.css' },
         'other.css': { source: 'keep', name: 'other.css' },
         'chunk.js': { name: 'devup-ui-9.css' },
       } as unknown as Record<string, { source: string; name: string }>
@@ -429,8 +433,22 @@ describe('devupUIVitePlugin', () => {
 
       expect(bundle['base.css'].source).toEqual('sheet:null')
       expect(bundle['three.css'].source).toEqual('sheet:3')
+      expect(bundle['nested.css'].source).toEqual('sheet:4')
       expect(bundle['other.css'].source).toEqual('keep')
       expect(bundle['chunk.js']).not.toHaveProperty('source')
+    })
+
+    it('leaves an app asset whose name merely ends in devup-ui.css alone', async () => {
+      getCssSpy.mockImplementation(
+        (fileNum: number | null) => `sheet:${fileNum}`,
+      )
+      const bundle = {
+        'vendor.css': { source: 'app styles', name: 'vendor-devup-ui.css' },
+      } as unknown as Record<string, { source: string; name: string }>
+
+      await createPlugin({}).generateBundle({}, bundle)
+
+      expect(bundle['vendor.css'].source).toEqual('app styles')
     })
 
     it('ignores the load-time snapshot so output does not depend on module order', async () => {

--- a/packages/vite-plugin/src/__tests__/plugin.test.ts
+++ b/packages/vite-plugin/src/__tests__/plugin.test.ts
@@ -45,8 +45,14 @@ interface ViteTestPlugin {
   name: string
   enforce: 'pre'
   apply: () => boolean
-  config: (this: { meta?: ConfigHookMeta } | void) => ViteConfig
-  configResolved: () => Promise<void>
+  config: (
+    this: { meta?: ConfigHookMeta } | void,
+    userConfig?: ViteConfig,
+  ) => ViteConfig
+  configResolved: (config?: {
+    command?: 'serve' | 'build'
+    root?: string
+  }) => Promise<void>
   watchChange: (id: string) => Promise<void>
   handleHotUpdate: (context: {
     file: string
@@ -102,8 +108,12 @@ const ROLLDOWN_VITE_META: ConfigHookMeta = {
   rolldownVersion: '1.2.5',
 }
 
-function callConfig(plugin: ViteTestPlugin, meta?: ConfigHookMeta): ViteConfig {
-  return plugin.config.call(meta ? { meta } : undefined)
+function callConfig(
+  plugin: ViteTestPlugin,
+  meta?: ConfigHookMeta,
+  userConfig?: ViteConfig,
+): ViteConfig {
+  return plugin.config.call(meta ? { meta } : undefined, userConfig)
 }
 
 const { basename, join, resolve, relative: originalRelative } = nodePath
@@ -324,17 +334,152 @@ describe('devupUIVitePlugin', () => {
         expect(build?.rollupOptions !== undefined).toBe(!usesRolldownOptions)
       },
     )
+
+    it('chains the user manualChunks instead of replacing it', () => {
+      const userManualChunks = mock((id: string) =>
+        id === 'vendor.js' ? 'vendor' : undefined,
+      )
+      const output = callConfig(createPlugin({}), ROLLUP_META, {
+        build: {
+          rollupOptions: { output: { manualChunks: userManualChunks } },
+        },
+      }).build?.rollupOptions?.output
+
+      expect(output?.manualChunks?.('devup-ui.css', 'code')).toEqual(
+        'devup-ui.css',
+      )
+      expect(output?.manualChunks?.('vendor.js', 'code')).toEqual('vendor')
+      expect(output?.manualChunks?.('other.js', 'code')).toBeUndefined()
+      expect(userManualChunks).not.toHaveBeenCalledWith('devup-ui.css', 'code')
+    })
+
+    it('reads the user manualChunks from the array form of output', () => {
+      const userManualChunks = mock(() => 'vendor')
+      const output = callConfig(createPlugin({}), ROLLUP_META, {
+        build: {
+          rollupOptions: {
+            output: [{ manualChunks: userManualChunks }] as never,
+          },
+        },
+      }).build?.rollupOptions?.output
+
+      expect(output?.manualChunks?.('devup-ui.css', 'code')).toEqual(
+        'devup-ui.css',
+      )
+      expect(output?.manualChunks?.('vendor.js', 'code')).toEqual('vendor')
+    })
+
+    it.each([
+      ['no user output', {} as ViteConfig],
+      [
+        'a non-function manualChunks',
+        {
+          build: {
+            rollupOptions: { output: { manualChunks: { a: ['b'] } as never } },
+          },
+        } as ViteConfig,
+      ],
+    ])('tolerates %s', (_name, userConfig) => {
+      const output = callConfig(createPlugin({}), ROLLUP_META, userConfig).build
+        ?.rollupOptions?.output
+      expect(output?.manualChunks?.('devup-ui.css', 'code')).toEqual(
+        'devup-ui.css',
+      )
+      expect(output?.manualChunks?.('other.js', 'code')).toBeUndefined()
+    })
+  })
+
+  describe('deterministic css output', () => {
+    it('creates the css dir before writing into it', async () => {
+      const order: string[] = []
+      existsSyncSpy.mockReturnValue(false)
+      mkdirSpy.mockImplementation(async (dir: string) => {
+        order.push(`mkdir:${dir}`)
+        await new Promise((r) => setTimeout(r, 5))
+        order.push(`mkdir-done:${dir}`)
+        return undefined
+      })
+      writeFileSpy.mockImplementation(async (file: string) => {
+        order.push(`write:${file}`)
+        return undefined
+      })
+
+      await createPlugin({}).configResolved()
+
+      const cssDir = resolve('df', 'devup-ui')
+      const mkdirDone = order.indexOf(`mkdir-done:${cssDir}`)
+      const wroteCss = order.indexOf(`write:${join(cssDir, 'devup-ui.css')}`)
+      expect(mkdirDone).toBeGreaterThanOrEqual(0)
+      expect(wroteCss).toBeGreaterThan(mkdirDone)
+    })
+
+    it('rewrites every devup css asset from the finished sheet', async () => {
+      getCssSpy.mockImplementation(
+        (fileNum: number | null) => `sheet:${fileNum}`,
+      )
+      const plugin = createPlugin({})
+      const bundle = {
+        'base.css': { source: 'stale', name: 'devup-ui.css' },
+        'three.css': { source: 'stale', name: 'devup-ui-3.css' },
+        'other.css': { source: 'keep', name: 'other.css' },
+        'chunk.js': { name: 'devup-ui-9.css' },
+      } as unknown as Record<string, { source: string; name: string }>
+
+      await plugin.generateBundle({}, bundle)
+
+      expect(bundle['base.css'].source).toEqual('sheet:null')
+      expect(bundle['three.css'].source).toEqual('sheet:3')
+      expect(bundle['other.css'].source).toEqual('keep')
+      expect(bundle['chunk.js']).not.toHaveProperty('source')
+    })
+
+    it('ignores the load-time snapshot so output does not depend on module order', async () => {
+      getCssSpy.mockReturnValue('early partial sheet')
+      const plugin = createPlugin({})
+      plugin.load('devup-ui.css')
+
+      getCssSpy.mockReturnValue('final complete sheet')
+      const bundle = { 'base.css': { source: '', name: 'devup-ui.css' } }
+      await plugin.generateBundle({}, bundle)
+
+      expect(bundle['base.css'].source).toEqual('final complete sheet')
+    })
+
+    it('resolves a stable id during build', async () => {
+      const plugin = createPlugin({})
+      await plugin.configResolved({ command: 'build' })
+      const importer = join('df', 'devup-ui', 'devup-ui.css')
+
+      const first = plugin.resolveId('devup-ui.css', importer)
+      const second = plugin.resolveId('devup-ui.css', importer)
+
+      expect(first).toEqual(join(resolve('df', 'devup-ui'), 'devup-ui.css'))
+      expect(first).toEqual(second)
+      expect(first).not.toContain('?t=')
+    })
+
+    it('cache-busts the id during dev so a growing sheet invalidates', async () => {
+      const plugin = createPlugin({})
+      await plugin.configResolved({ command: 'serve' })
+
+      expect(
+        plugin.resolveId(
+          'devup-ui.css',
+          join('df', 'devup-ui', 'devup-ui.css'),
+        ),
+      ).toContain('?t=')
+    })
   })
 
   it('should include default editor packages in vite config', () => {
     const plugin = createPlugin({})
-    const config = plugin.config()
+    const config = callConfig(plugin)
 
-    expect(config.optimizeDeps.exclude).toEqual([
+    expect(config.optimizeDeps!.exclude).toEqual([
       '@devup-ui/components',
       '@devup-editor/react',
     ])
-    expect(config.ssr.noExternal).toEqual([/@devup-ui/, /@devup-editor/])
+    expect(config.ssr!.noExternal).toEqual([/@devup-ui/, /@devup-editor/])
   })
 
   it.each(
@@ -386,7 +531,7 @@ describe('devupUIVitePlugin', () => {
       expect(registerThemeSpy).toHaveBeenCalledWith({})
     }
 
-    const config = plugin.config()
+    const config = callConfig(plugin)
     if (options.getDefaultTheme) {
       expect(config.define).toEqual({
         'process.env.DEVUP_UI_DEFAULT_THEME': JSON.stringify(

--- a/packages/vite-plugin/src/__tests__/plugin.test.ts
+++ b/packages/vite-plugin/src/__tests__/plugin.test.ts
@@ -17,13 +17,24 @@ import {
 import { DevupUI } from '../plugin'
 
 type CodeExtractResult = ReturnType<typeof wasm.codeExtract>
+interface ConfigHookMeta {
+  viteVersion?: string
+  rollupVersion?: string
+  rolldownVersion?: string
+}
+interface CodeSplittingGroup {
+  name: (id: string) => string | null
+  minSize?: number
+  minShareCount?: number
+}
+interface ViteOutputOptions {
+  manualChunks?: (id: string, code: string) => string | undefined
+  codeSplitting?: { groups?: CodeSplittingGroup[] }
+}
 interface ViteConfig {
   build?: {
-    rollupOptions?: {
-      output?: {
-        manualChunks?: (id: string, code: string) => string | undefined
-      }
-    }
+    rollupOptions?: { output?: ViteOutputOptions }
+    rolldownOptions?: { output?: ViteOutputOptions }
   }
   optimizeDeps?: { exclude?: string[] }
   ssr?: { noExternal?: RegExp[] }
@@ -34,7 +45,7 @@ interface ViteTestPlugin {
   name: string
   enforce: 'pre'
   apply: () => boolean
-  config: () => ViteConfig
+  config: (this: { meta?: ConfigHookMeta } | void) => ViteConfig
   configResolved: () => Promise<void>
   watchChange: (id: string) => Promise<void>
   handleHotUpdate: (context: {
@@ -76,7 +87,26 @@ function createPlugin(options?: Parameters<typeof DevupUI>[0]): ViteTestPlugin {
   return DevupUI(options) as unknown as ViteTestPlugin
 }
 
-const { join, resolve, relative: originalRelative } = nodePath
+const ROLLUP_META: ConfigHookMeta = {
+  viteVersion: '7.1.14',
+  rollupVersion: '4.52.5',
+}
+const ROLLDOWN_META: ConfigHookMeta = {
+  viteVersion: '8.2.2',
+  rollupVersion: '4.52.5',
+  rolldownVersion: '1.2.5',
+}
+const ROLLDOWN_VITE_META: ConfigHookMeta = {
+  viteVersion: '7.1.14',
+  rollupVersion: '4.52.5',
+  rolldownVersion: '1.2.5',
+}
+
+function callConfig(plugin: ViteTestPlugin, meta?: ConfigHookMeta): ViteConfig {
+  return plugin.config.call(meta ? { meta } : undefined)
+}
+
+const { basename, join, resolve, relative: originalRelative } = nodePath
 
 let existsSyncSpy: ReturnType<typeof spyOn>
 let mkdirSpy: ReturnType<typeof spyOn>
@@ -158,19 +188,142 @@ describe('devupUIVitePlugin', () => {
     expect(setDebugSpy).toHaveBeenCalledWith(options.debug)
     if (options.extractCss) {
       expect(
-        plugin
-          .config()
-          .build?.rollupOptions?.output?.manualChunks?.('devup-ui.css', 'code'),
+        callConfig(
+          plugin,
+          ROLLUP_META,
+        ).build?.rollupOptions?.output?.manualChunks?.('devup-ui.css', 'code'),
       ).toEqual('devup-ui.css')
 
       expect(
-        plugin
-          .config()
-          .build?.rollupOptions?.output?.manualChunks?.('other.css', 'code'),
+        callConfig(
+          plugin,
+          ROLLUP_META,
+        ).build?.rollupOptions?.output?.manualChunks?.('other.css', 'code'),
       ).toEqual(undefined)
+
+      expect(
+        callConfig(
+          plugin,
+          ROLLDOWN_META,
+        ).build?.rolldownOptions?.output?.codeSplitting?.groups?.[0]?.name(
+          'devup-ui.css',
+        ),
+      ).toEqual('devup-ui.css')
+
+      expect(
+        callConfig(
+          plugin,
+          ROLLDOWN_META,
+        ).build?.rolldownOptions?.output?.codeSplitting?.groups?.[0]?.name(
+          'other.css',
+        ),
+      ).toBeNull()
     } else {
-      expect(plugin.config().build).toBeUndefined()
+      expect(callConfig(plugin, ROLLUP_META).build).toBeUndefined()
+      expect(callConfig(plugin, ROLLDOWN_META).build).toBeUndefined()
     }
+  })
+
+  describe('devup css chunk merging', () => {
+    const devupCssIds = [
+      'devup-ui.css',
+      'devup-ui-0.css',
+      'devup-ui-12.css',
+      join('/p', 'df', 'devup-ui', 'devup-ui-3.css'),
+      `${join('/p', 'df', 'devup-ui', 'devup-ui.css')}?t=1730000000000`,
+    ]
+    const otherIds = [
+      'other.css',
+      'devup-ui.js',
+      'my-devup-ui-styles.css',
+      join('/p', 'src', 'app.tsx'),
+    ]
+
+    function rolldownGroup(meta: ConfigHookMeta) {
+      const build = callConfig(createPlugin({}), meta).build
+      const groups =
+        build?.rolldownOptions?.output?.codeSplitting?.groups ??
+        build?.rollupOptions?.output?.codeSplitting?.groups
+      expect(groups).toHaveLength(1)
+      return groups![0]!
+    }
+
+    it('names every devup css module after its own file on rollup', () => {
+      const manualChunks = callConfig(createPlugin({}), ROLLUP_META).build
+        ?.rollupOptions?.output?.manualChunks
+      for (const id of devupCssIds) {
+        expect(manualChunks?.(id, 'code')).toEqual(basename(id).split('?')[0])
+      }
+      for (const id of otherIds) {
+        expect(manualChunks?.(id, 'code')).toBeUndefined()
+      }
+    })
+
+    it('names every devup css module after its own file on rolldown', () => {
+      const group = rolldownGroup(ROLLDOWN_META)
+      for (const id of devupCssIds) {
+        expect(group.name(id)).toEqual(basename(id).split('?')[0])
+      }
+      for (const id of otherIds) {
+        expect(group.name(id)).toBeNull()
+      }
+    })
+
+    it('opts the group out of a framework minSize / minShareCount fallback', () => {
+      // Framework plugins set `codeSplitting.minSize` (vinext uses 10_000 for
+      // its client environment); without an explicit per-group value that
+      // fallback folds the devup css chunks back into every route chunk.
+      const group = rolldownGroup(ROLLDOWN_META)
+      expect(group.minSize).toBe(0)
+      expect(group.minShareCount).toBe(1)
+    })
+
+    const chunkingCases: [
+      string,
+      ConfigHookMeta | undefined,
+      'manualChunks' | 'codeSplitting',
+    ][] = [
+      ['rollup', ROLLUP_META, 'manualChunks'],
+      ['rolldown on vite 8', ROLLDOWN_META, 'codeSplitting'],
+      ['rolldown on vite 7', ROLLDOWN_VITE_META, 'codeSplitting'],
+      ['unknown bundler', undefined, 'manualChunks'],
+      [
+        'rolldown without a vite version',
+        { rolldownVersion: '1.2.5' },
+        'codeSplitting',
+      ],
+    ]
+
+    it.each(chunkingCases)(
+      'picks the %s chunking option',
+      (_name, meta, expected) => {
+        const build = callConfig(createPlugin({}), meta).build
+        // Vite drops one of the two when a plugin returns both.
+        expect(build?.rollupOptions && build?.rolldownOptions).toBeFalsy()
+        const output =
+          build?.rolldownOptions?.output ?? build?.rollupOptions?.output
+        expect(output?.manualChunks !== undefined).toBe(
+          expected === 'manualChunks',
+        )
+        expect(output?.codeSplitting !== undefined).toBe(
+          expected === 'codeSplitting',
+        )
+      },
+    )
+
+    const optionKeyCases: [string, ConfigHookMeta, boolean][] = [
+      ['vite 8', ROLLDOWN_META, true],
+      ['rolldown-vite on vite 7', ROLLDOWN_VITE_META, false],
+    ]
+
+    it.each(optionKeyCases)(
+      'puts rolldown options under the right key on %s',
+      (_name, meta, usesRolldownOptions) => {
+        const build = callConfig(createPlugin({}), meta).build
+        expect(build?.rolldownOptions !== undefined).toBe(usesRolldownOptions)
+        expect(build?.rollupOptions !== undefined).toBe(!usesRolldownOptions)
+      },
+    )
   })
 
   it('should include default editor packages in vite config', () => {

--- a/packages/vite-plugin/src/plugin.ts
+++ b/packages/vite-plugin/src/plugin.ts
@@ -50,6 +50,20 @@ interface ConfigHookMeta {
 }
 
 /**
+ * Vite merges a plugin's `config()` result over the user's, replacing function
+ * values outright, so returning a bare `manualChunks` silently drops one the
+ * app already had. Rolldown's `codeSplitting.groups` needs no equivalent —
+ * arrays are concatenated, not replaced.
+ */
+function getUserManualChunks(userConfig: UserConfig | undefined) {
+  const output = userConfig?.build?.rollupOptions?.output
+  const first = Array.isArray(output) ? output[0] : output
+  return typeof first?.manualChunks === 'function'
+    ? first.manualChunks
+    : undefined
+}
+
+/**
  * Build options that merge devup-ui CSS modules into shared chunks.
  *
  * Rollup only understands `output.manualChunks`. Rolldown (Vite 8) removed the
@@ -67,13 +81,15 @@ interface ConfigHookMeta {
  */
 function createCssChunkBuildOptions(
   meta: ConfigHookMeta | undefined,
+  userConfig?: UserConfig,
 ): UserConfig['build'] {
   if (!meta?.rolldownVersion) {
+    const userManualChunks = getUserManualChunks(userConfig)
     return {
       rollupOptions: {
         output: {
-          manualChunks(id: string) {
-            return getDevupCssChunkName(id)
+          manualChunks(id, ...rest) {
+            return getDevupCssChunkName(id) ?? userManualChunks?.(id, ...rest)
           },
         },
       },
@@ -150,14 +166,14 @@ async function writeDataFiles(
     console.error(error)
     registerTheme({})
   }
-  await Promise.all([
-    !existsSync(options.cssDir)
-      ? mkdir(options.cssDir, { recursive: true })
-      : Promise.resolve(),
-    !options.singleCss
-      ? writeFile(join(options.cssDir, 'devup-ui.css'), getCss(null, false))
-      : Promise.resolve(),
-  ])
+  // Sequential: writing into cssDir concurrently with its own mkdir loses the
+  // race on a cold start (no `df/`) and fails the build with ENOENT.
+  if (!existsSync(options.cssDir)) {
+    await mkdir(options.cssDir, { recursive: true })
+  }
+  if (!options.singleCss) {
+    await writeFile(join(options.cssDir, 'devup-ui.css'), getCss(null, false))
+  }
 }
 
 export function DevupUI({
@@ -179,9 +195,11 @@ export function DevupUI({
   }
   const importAliases = mergeImportAliases(userImportAliases)
   const cssMap = new Map()
+  let isServe = false
   return {
     name: 'devup-ui',
     async configResolved(config) {
+      isServe = config?.command === 'serve'
       if (!existsSync(distDir)) await mkdir(distDir, { recursive: true })
       await writeFile(join(distDir, '.gitignore'), '*', 'utf-8')
       await writeDataFiles({
@@ -249,7 +267,7 @@ export function DevupUI({
         }
       }
     },
-    config(this: { meta?: ConfigHookMeta } | void) {
+    config(this: { meta?: ConfigHookMeta } | void, userConfig: UserConfig) {
       const theme = getDefaultTheme()
       const define: Record<string, string> = {}
       if (theme) {
@@ -270,7 +288,7 @@ export function DevupUI({
         },
       }
       if (extractCss) {
-        ret.build = createCssChunkBuildOptions(this?.meta)
+        ret.build = createCssChunkBuildOptions(this?.meta, userConfig)
       }
       return ret
     },
@@ -320,10 +338,15 @@ export function DevupUI({
     resolveId(id, importer) {
       const fileName = basename(id).split('?')[0]
       if (
-        /devup-ui(-\d+)?\.css$/.test(fileName) &&
+        DEVUP_CSS_FILE_RE.test(fileName) &&
         resolve(importer ? join(dirname(importer), id) : id) ===
           resolve(join(cssDir, fileName))
       ) {
+        // Dev re-resolves through a changing id so a growing sheet invalidates
+        // the module. A build must not: a per-resolution id forks one file into
+        // several modules and makes output hashes differ between identical
+        // builds.
+        if (!isServe) return join(cssDir, fileName)
         return join(
           cssDir,
           `${fileName}?t=${
@@ -335,7 +358,7 @@ export function DevupUI({
     },
     load(id) {
       const fileName = basename(id).split('?')[0]
-      if (/devup-ui(-\d+)?\.css$/.test(fileName)) {
+      if (DEVUP_CSS_FILE_RE.test(fileName)) {
         const fileNum = getFileNumByFilename(fileName)
         const css = getCss(fileNum, false)
         cssMap.set(fileNum, css)
@@ -402,11 +425,17 @@ export function DevupUI({
     async generateBundle(_options, bundle) {
       if (!extractCss) return
 
-      const cssFile = Object.keys(bundle).find(
-        (file) => bundle[file].name === 'devup-ui.css',
-      )
-      if (cssFile && 'source' in bundle[cssFile]) {
-        bundle[cssFile].source = cssMap.get(null) ?? ''
+      // `load` can only snapshot the sheet as it stood when the module was
+      // pulled in, and module order varies per build, so the emitted asset was
+      // neither complete nor reproducible. Every transform has run by now, so
+      // re-read each file's finished sheet instead. Applies to `devup-ui-N.css`
+      // too, not just the base sheet.
+      for (const file of Object.keys(bundle)) {
+        const asset = bundle[file]
+        const name = asset.name
+        if (!name || !DEVUP_CSS_FILE_RE.test(name)) continue
+        if (!('source' in asset)) continue
+        asset.source = getCss(getFileNumByFilename(name), false)
       }
     },
   }

--- a/packages/vite-plugin/src/plugin.ts
+++ b/packages/vite-plugin/src/plugin.ts
@@ -27,6 +27,80 @@ import {
 } from '@devup-ui/wasm'
 import type { ModuleNode, PluginOption, UserConfig } from 'vite'
 
+/** CSS entry files emitted by devup-ui: `devup-ui.css`, `devup-ui-3.css`, ... */
+const DEVUP_CSS_FILE_RE = /devup-ui(-\d+)?\.css$/
+
+/**
+ * Names each devup CSS module after its own file, so every module is emitted
+ * once and shared by all of its importers.
+ */
+function getDevupCssChunkName(id: string): string | undefined {
+  const fileName = basename(id).split('?')[0]
+  return DEVUP_CSS_FILE_RE.test(fileName) ? fileName : undefined
+}
+
+/**
+ * Subset of the plugin context Vite binds to the `config` hook. Vite >= 6.1
+ * exposes `meta.viteVersion`; a Rolldown-powered Vite also exposes
+ * `meta.rolldownVersion`.
+ */
+interface ConfigHookMeta {
+  viteVersion?: string
+  rolldownVersion?: string
+}
+
+/**
+ * Build options that merge devup-ui CSS modules into shared chunks.
+ *
+ * Rollup only understands `output.manualChunks`. Rolldown (Vite 8) removed the
+ * object form and *silently ignores* the function form as soon as anything sets
+ * `output.codeSplitting` — which framework plugins do per environment (vinext
+ * sets it for its client and rsc environments, so only its ssr environment
+ * still honors `manualChunks`). The shared CSS then gets copied into every
+ * route chunk instead of being emitted once.
+ *
+ * `output.codeSplitting.groups` is Rolldown's replacement, and merges with the
+ * groups a framework plugin already registered.
+ *
+ * @see https://vite.dev/guide/migration.html#removed-object-form-build-rollupoptions-output-manualchunks-and-deprecate-function-form-one
+ * @see https://rolldown.rs/in-depth/manual-code-splitting
+ */
+function createCssChunkBuildOptions(
+  meta: ConfigHookMeta | undefined,
+): UserConfig['build'] {
+  if (!meta?.rolldownVersion) {
+    return {
+      rollupOptions: {
+        output: {
+          manualChunks(id: string) {
+            return getDevupCssChunkName(id)
+          },
+        },
+      },
+    }
+  }
+  const output = {
+    codeSplitting: {
+      groups: [
+        {
+          name: (id: string) => getDevupCssChunkName(id) ?? null,
+          // Opt out of any framework-level `minSize` / `minShareCount`
+          // fallback, which would otherwise fold these small CSS chunks back
+          // into every route chunk that imports them.
+          minSize: 0,
+          minShareCount: 1,
+        },
+      ],
+    },
+  }
+  // Vite 8 renamed `build.rollupOptions` to `build.rolldownOptions`. Older
+  // Rolldown-powered builds (rolldown-vite on Vite 7) keep the old name, and
+  // supplying both would make Vite drop one of them.
+  return Number.parseInt(meta.viteVersion ?? '', 10) >= 8
+    ? { rolldownOptions: { output } }
+    : { rollupOptions: { output } }
+}
+
 export interface DevupUIPluginOptions {
   package: string
   cssDir: string
@@ -175,7 +249,7 @@ export function DevupUI({
         }
       }
     },
-    config() {
+    config(this: { meta?: ConfigHookMeta } | void) {
       const theme = getDefaultTheme()
       const define: Record<string, string> = {}
       if (theme) {
@@ -196,19 +270,7 @@ export function DevupUI({
         },
       }
       if (extractCss) {
-        ret.build = {
-          rollupOptions: {
-            output: {
-              manualChunks(id) {
-                // merge devup css files
-                const fileName = basename(id).split('?')[0]
-                if (/devup-ui(-\d+)?\.css$/.test(fileName)) {
-                  return fileName
-                }
-              },
-            },
-          },
-        }
+        ret.build = createCssChunkBuildOptions(this?.meta)
       }
       return ret
     },

--- a/packages/vite-plugin/src/plugin.ts
+++ b/packages/vite-plugin/src/plugin.ts
@@ -27,8 +27,14 @@ import {
 } from '@devup-ui/wasm'
 import type { ModuleNode, PluginOption, UserConfig } from 'vite'
 
-/** CSS entry files emitted by devup-ui: `devup-ui.css`, `devup-ui-3.css`, ... */
-const DEVUP_CSS_FILE_RE = /devup-ui(-\d+)?\.css$/
+/**
+ * CSS entry files emitted by devup-ui: `devup-ui.css`, `devup-ui-3.css`, ...
+ *
+ * Anchored at BOTH ends and matched against a bare file name. Without `^` it
+ * also accepts an app's own `vendor-devup-ui.css`, which `generateBundle` would
+ * then overwrite with the devup sheet.
+ */
+const DEVUP_CSS_FILE_RE = /^devup-ui(-\d+)?\.css$/
 
 /**
  * Names each devup CSS module after its own file, so every module is emitted
@@ -432,10 +438,11 @@ export function DevupUI({
       // too, not just the base sheet.
       for (const file of Object.keys(bundle)) {
         const asset = bundle[file]
-        const name = asset.name
-        if (!name || !DEVUP_CSS_FILE_RE.test(name)) continue
+        if (!asset.name) continue
+        const cssName = getDevupCssChunkName(asset.name)
+        if (!cssName) continue
         if (!('source' in asset)) continue
-        asset.source = getCss(getFileNumByFilename(name), false)
+        asset.source = getCss(getFileNumByFilename(cssName), false)
       }
     },
   }


### PR DESCRIPTION
## Problem

On Vite 8 (Rolldown), `@devup-ui/vite-plugin` stops merging devup CSS into shared chunks, so the extracted atoms get welded into route chunks instead of being emitted once.

`config()` returned `build.rollupOptions.output.manualChunks`. Vite 8 removed the object form and deprecated the function form, and **Rolldown discards `manualChunks` entirely as soon as anything sets `output.codeSplitting`**.

## Root cause ??measured, not guessed

Built `benchmark/vinext-devup-ui` (vinext 1.0.0-beta.8 = Vite 8.2.2 + Rolldown). Rolldown prints the reason itself, once per environment that sets `codeSplitting`:

```
WARN  manualChunks option is ignored because the codeSplitting option is specified.
```

| vinext build step | environment | sets `output.codeSplitting` | `manualChunks` |
| --- | --- | --- | --- |
| [1/5] analyze client references | rsc | yes | **ignored** |
| [2/5] analyze server references | ssr | no | honored |
| [3/5] build rsc environment | rsc | yes | **ignored** |
| [4/5] build client environment | client | yes | **ignored** |
| [5/5] build ssr environment | ssr | no | honored |

vinext sets it in [`createClientCodeSplittingConfig`](https://github.com/cloudflare/vinext) (client, `minSize: 10_000`) and `createRscFrameworkChunkOutputConfig` (rsc).

That is exactly the reported "partial operation", and it is visible in the emitted CSS file names. Same build, same source, two environments:

```
dist/server/ssr/_next/static/css/     <- manualChunks honored
  devup-ui.css  devup-ui-0.css  devup-ui-1.css ... devup-ui-15.css   (one chunk per devup css module)

dist/client/_next/static/css/         <- manualChunks discarded
  devup-ui.css  page.*.css x13  Section*.css                          (devup css absorbed into route chunks)
```

Confirmed from the other direction too: a plain Vite 8 SPA (`apps/vite`, nothing sets `codeSplitting`) honors `manualChunks` and emits `assets/devup-ui-u84_3Epu.css` ??so the breakage is scoped precisely to environments a framework plugin configures.

## Fix

Branch on the bundler reported by the `config` hook's plugin context (`this.meta`):

| context | emitted option |
| --- | --- |
| no `rolldownVersion` (Rollup / Vite ??7) | `build.rollupOptions.output.manualChunks` |
| `rolldownVersion` + `viteVersion` ??8 | `build.rolldownOptions.output.codeSplitting.groups` |
| `rolldownVersion` + Vite 7 (rolldown-vite) | `build.rollupOptions.output.codeSplitting.groups` |

Both paths share one predicate, so a devup CSS module keeps its own file name as its chunk name and is emitted once for all importers.

Only ever one of the two keys is returned ??Vite warns and drops `rollupOptions` if a plugin supplies both.

The group pins `minSize: 0` / `minShareCount: 1`. `codeSplitting.minSize` is a *global fallback for every group*, so vinext's `minSize: 10_000` would otherwise fold these small CSS chunks straight back into the route chunks the fix just pulled them out of.

## Results

`benchmark/vinext-devup-ui`, 13 routes over 8 shared sections (expanded from 1 route in this PR ??a single-route app cannot exercise route-level chunking at all). Rules counted by splitting CSS on `}`.

Client bundle (what ships to the browser):

| plugin | `manualChunks` warnings | CSS files | total | unique rules | duplicate rules | duplicate |
| --- | --- | --- | --- | --- | --- | --- |
| before | 3 | 22 (`page.*`, `Section*`) | 14.7 KB | 582 | 4 | 0.7% |
| **after** | **0** | **22 (`devup-ui-*`)** | **14.6 KB** | **580** | **0** | **0.0%** |

Every devup CSS module is a dedicated shared chunk again, in every environment.

Also verified `manualChunks` removal makes things worse, matching the report's 52% ??59%: dropping the option entirely regresses total CSS to 29.5 KB / 591 duplicate rules vs. 29.3 KB / 584 before and 29.1 KB / 580 after ??the ssr environment loses its dedicated chunks too.

`apps/vite` (plain Vite 8) emits a byte-identical `devup-ui-u84_3Epu.css` before and after, so the non-framework path is unchanged.

### One finding worth flagging

The reported 52% figure is dominated by something chunking cannot fix. vinext emits CSS into both `dist/client` and `dist/server/ssr`, and those two sets are **100% identical** (580/580 rules shared, 14.6 KB each) both before and after this change. Measured across the whole `dist/` that alone is a flat 50%. The intra-environment duplication this PR removes is the part the bundler config actually controls.

Separately, `singleCss: true` surfaces a pre-existing extractor artifact: `getCss(null)` emits one `@media` rule up to 7 times. It already showed up at baseline in the ssr environment (the one where `manualChunks` worked, 5x there), so it is not a regression from this change ??it just becomes visible in the client bundle now that the client environment takes the same path. Left alone here.

## Tests

`packages/vite-plugin/src/__tests__/plugin.test.ts` pins the new path at the same level as the existing `manualChunks` assertions ??the group's `name()` is invoked directly:

- both paths map `devup-ui.css`, `devup-ui-0.css`, `devup-ui-12.css`, absolute ids and `?t=`-suffixed ids to their own file name, and reject `other.css` / `devup-ui.js` / `my-devup-ui-styles.css` / `.tsx`
- `minSize` is `0` and `minShareCount` is `1`
- correct option chosen for rollup / rolldown+vite8 / rolldown-vite / unknown context / rolldown without a vite version
- `rollupOptions` and `rolldownOptions` are never both returned
- `build` stays undefined when `extractCss: false`

5101 tests pass, `packages/vite-plugin/src/plugin.ts` at 100% function and line coverage, `bun lint` clean, `cargo fmt`/`clippy`/`tarpaulin` unaffected (no Rust changes).

Patch bump for `@devup-ui/vite-plugin` via `.changepacks`.



---

# Follow-up hardening (commit 2)

Auditing the plugin while measuring the chunking fix turned up four more defects. All are verified by build artifacts, and each regression test was checked to fail on the old code.

## 1. Cold-start builds crash (`ENOENT`)

`writeDataFiles` put the `mkdir` of `cssDir` and a `writeFile` *into* `cssDir` in the same `Promise.all`, so the write could lose the race:

```
Error: ENOENT: no such file or directory, open '...\df\devup-ui\devup-ui.css'
  at async Promise.all (index 1)
  at async BasicMinimalPluginContext.configResolved
```

Hit repeatedly on a fresh clone / cleared `df/` while measuring. Now sequential. The regression test records call order and fails on the old code (`write` at index 5, `mkdir-done` at 6).

## 2. Emitted CSS depended on module order

`load()` can only snapshot the sheet as it stood when the module was pulled in, and `generateBundle` then patched **only** `devup-ui.css` from that cached snapshot ? the numbered `devup-ui-N.css` assets kept whatever partial sheet they happened to capture.

`generateBundle` now re-reads every devup asset from the finished sheet via `getCss(fileNum)`, after all transforms have run.

## 3. `?t=` in module ids forked one file into many modules

`resolveId` embedded `Date.now()` in the id on every resolution. In `singleCss` mode `devup-ui.css` is imported by every source file, so each importer resolved a *different* module id ? the same sheet was concatenated into the chunk repeatedly.

Measured on `benchmark/vinext-devup-ui` with `singleCss: true`:

| | rules | duplicate rule strings |
| --- | --- | --- |
| before | 260 | 6 (`7x @media (min-width:480px){...}`) |
| **after** | **254** | **0** |

The cache-buster is now dev-only, so HMR invalidation is unchanged while builds get one stable module per file.

> This also resolves the `singleCss` `@media` duplication flagged in the first commit. It was **not** an extractor bug ? `getCss()` emits the rule exactly once (verified directly against the wasm); the copies came from this module forking, which is why they appeared post-minified as `@media (min-width:480px)` rather than the extractor's `@media(min-width:480px)`.

## 4. The app's own `manualChunks` was silently dropped

Vite merges a plugin's `config()` over the user's and replaces function values outright, so returning a bare `manualChunks` deleted one the app already had. It is now chained ? devup CSS first, then the user's function. `codeSplitting.groups` needs no equivalent because arrays are concatenated.

## Cross-environment state

With `generateBundle` reading the live sheet instead of the shared `cssMap`, build output no longer depends on which of vinext's five environment passes populated that cache last.

## Known limitation, not fixed here

Per-file CSS hashes still differ between two identical cold builds. The cause is **not** in this plugin: devup-ui assigns per-file numbers and class-name prefixes in transform arrival order, which the bundler parallelizes. Proof ? across two identical builds the JS chunks move too, while a devup-free vendor chunk does not:

```
build 1: index-CctZT8Ma.js  page-B3ldZVRg.js   framework-DTZGTDtF.js
build 2: index-OxEI0ixc.js  page-87OmBnhZ.js   framework-DTZGTDtF.js   <- vendor stable
```

Because the prefixes are baked into the emitted JS, stabilising only the CSS side would not help. A real fix is deterministic file numbering across the toolchain; `webpack-plugin`/`next-plugin` persist the file map but only in watch mode, so they share the property. Left for a separate change.

## Verification

5110 tests pass, `packages/vite-plugin/src/plugin.ts` at 100% function and line coverage, `bun lint` clean, cold-start build green, `apps/vite` (plain Vite 8) unchanged.