### PR TITLE
Assign devup file numbers by sorted path so builds are reproducible

### DIFF
--- a/.changepacks/changepack_log_Zt4nB8yWqLs1EoUvPmK7d.json
+++ b/.changepacks/changepack_log_Zt4nB8yWqLs1EoUvPmK7d.json
@@ -1,0 +1,7 @@
+{
+  "changes": {
+    "packages/vite-plugin/package.json": "Patch"
+  },
+  "note": "Assign devup file numbers by sorted path so builds are reproducible",
+  "date": "2026-08-23T05:40:00.000000000Z"
+}

--- a/packages/vite-plugin/src/__tests__/plugin.test.ts
+++ b/packages/vite-plugin/src/__tests__/plugin.test.ts
@@ -395,15 +395,18 @@ describe('devupUIVitePlugin', () => {
   describe('deterministic file numbering', () => {
     let listSourceFilesSpy: ReturnType<typeof spyOn>
     let importFileMapSpy: ReturnType<typeof spyOn>
+    let exportFileMapSpy: ReturnType<typeof spyOn>
 
     beforeEach(() => {
       listSourceFilesSpy = spyOn(pluginUtils, 'listSourceFiles')
       importFileMapSpy = spyOn(wasm, 'importFileMap').mockReturnValue(undefined)
+      exportFileMapSpy = spyOn(wasm, 'exportFileMap').mockReturnValue('{}')
     })
 
     afterEach(() => {
       listSourceFilesSpy.mockRestore()
       importFileMapSpy.mockRestore()
+      exportFileMapSpy.mockRestore()
     })
 
     function onlyDirs(...dirs: string[]) {
@@ -436,6 +439,22 @@ describe('devupUIVitePlugin', () => {
       await createPlugin({}).configResolved({ root: '/p' })
 
       expect(importFileMapSpy).toHaveBeenCalledWith({ 'C:/p/src/a.tsx': 0 })
+    })
+
+    // A framework plugin resolves the config once per environment. Re-seeding
+    // drops the numbers already given to files outside src/ and app/, and since
+    // the sheet does not reset with the map, the next such file reuses a live
+    // number and its atoms overwrite the previous owner's.
+    it('leaves an already-populated map alone on a second configResolved', async () => {
+      onlyDirs('src')
+      listSourceFilesSpy.mockReturnValue(['/p/src/a.tsx'])
+      exportFileMapSpy.mockReturnValue(
+        '{"/p/src/a.tsx":0,"/monorepo/packages/ui/X.tsx":1}',
+      )
+
+      await createPlugin({}).configResolved({ root: '/p' })
+
+      expect(importFileMapSpy).not.toHaveBeenCalled()
     })
 
     it('scans app/ for App Router projects and dedupes across roots', async () => {

--- a/packages/vite-plugin/src/__tests__/plugin.test.ts
+++ b/packages/vite-plugin/src/__tests__/plugin.test.ts
@@ -389,6 +389,96 @@ describe('devupUIVitePlugin', () => {
     })
   })
 
+  describe('deterministic file numbering', () => {
+    let listSourceFilesSpy: ReturnType<typeof spyOn>
+    let importFileMapSpy: ReturnType<typeof spyOn>
+
+    beforeEach(() => {
+      listSourceFilesSpy = spyOn(pluginUtils, 'listSourceFiles')
+      importFileMapSpy = spyOn(wasm, 'importFileMap').mockReturnValue(undefined)
+    })
+
+    afterEach(() => {
+      listSourceFilesSpy.mockRestore()
+      importFileMapSpy.mockRestore()
+    })
+
+    function onlyDirs(...dirs: string[]) {
+      const wanted = new Set(dirs.map((d) => resolve('/p', d)))
+      existsSyncSpy.mockImplementation((path: string) => wanted.has(path))
+    }
+
+    it('numbers files by sorted path, not by transform arrival order', async () => {
+      onlyDirs('src')
+      // returned out of order on purpose: arrival order must not leak through
+      listSourceFilesSpy.mockReturnValue([
+        '/p/src/z.tsx',
+        '/p/src/a.tsx',
+        '/p/src/m.tsx',
+      ])
+
+      await createPlugin({}).configResolved({ root: '/p' })
+
+      expect(importFileMapSpy).toHaveBeenCalledWith({
+        '/p/src/a.tsx': 0,
+        '/p/src/m.tsx': 1,
+        '/p/src/z.tsx': 2,
+      })
+    })
+
+    it('normalizes windows separators to match vite module ids', async () => {
+      onlyDirs('src')
+      listSourceFilesSpy.mockReturnValue(['C:\\p\\src\\a.tsx'])
+
+      await createPlugin({}).configResolved({ root: '/p' })
+
+      expect(importFileMapSpy).toHaveBeenCalledWith({ 'C:/p/src/a.tsx': 0 })
+    })
+
+    it('scans app/ for App Router projects and dedupes across roots', async () => {
+      onlyDirs('src', 'app')
+      listSourceFilesSpy.mockImplementation((dir: string) =>
+        dir === resolve('/p', 'app')
+          ? ['/p/app/page.tsx', '/p/shared.tsx']
+          : ['/p/src/b.tsx', '/p/shared.tsx'],
+      )
+
+      await createPlugin({}).configResolved({ root: '/p' })
+
+      expect(importFileMapSpy).toHaveBeenCalledWith({
+        '/p/app/page.tsx': 0,
+        '/p/shared.tsx': 1,
+        '/p/src/b.tsx': 2,
+      })
+    })
+
+    it.each([
+      ['no conventional source dir exists', () => onlyDirs()],
+      [
+        'the source dir is empty',
+        () => {
+          onlyDirs('src')
+          listSourceFilesSpy.mockReturnValue([])
+        },
+      ],
+    ])('leaves numbering alone when %s', async (_name, setup) => {
+      setup()
+      await createPlugin({}).configResolved({ root: '/p' })
+      expect(importFileMapSpy).not.toHaveBeenCalled()
+    })
+
+    it('keeps building when the scan fails', async () => {
+      onlyDirs('src')
+      listSourceFilesSpy.mockImplementation(() => {
+        throw new Error('scan boom')
+      })
+
+      await createPlugin({}).configResolved({ root: '/p' })
+
+      expect(importFileMapSpy).not.toHaveBeenCalled()
+    })
+  })
+
   describe('deterministic css output', () => {
     it('creates the css dir before writing into it', async () => {
       const order: string[] = []
@@ -956,6 +1046,39 @@ describe('devupUIVitePlugin atom hoisting', () => {
       '/p/src/r1.tsx': [1],
     })
     expect(setAtomHoistSpy).toHaveBeenCalledWith(2)
+  })
+
+  it.each([
+    ['app', 'app'],
+    ['src', 'src'],
+  ])('scans %s/ when that is where the sources live', async (_name, dir) => {
+    existsSyncSpy.mockImplementation(
+      (path: string) => path === resolve('/p', dir),
+    )
+    computeFileReachSpy.mockReturnValue({
+      '/p/a.tsx': [0],
+      '/p/b.tsx': [1],
+    })
+
+    await runConfigResolved({ atomHoist: 2 }, { root: '/p' })
+
+    expect(computeFileReachSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ srcDir: resolve('/p', dir) }),
+    )
+  })
+
+  it('falls back to src/ when neither conventional dir exists', async () => {
+    existsSyncSpy.mockReturnValue(false)
+    computeFileReachSpy.mockReturnValue({
+      '/p/a.tsx': [0],
+      '/p/b.tsx': [1],
+    })
+
+    await runConfigResolved({ atomHoist: 2 }, { root: '/p' })
+
+    expect(computeFileReachSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ srcDir: resolve('/p', 'src') }),
+    )
   })
 
   it('clamps the threshold to a minimum of 2', async () => {

--- a/packages/vite-plugin/src/plugin.ts
+++ b/packages/vite-plugin/src/plugin.ts
@@ -9,6 +9,7 @@ import {
   createThemeInterfaceArgs,
   getFileNumByFilename,
   type ImportAliases,
+  listSourceFiles,
   loadDevupConfig,
   mergeImportAliases,
   planAtomHoist,
@@ -19,6 +20,7 @@ import {
   getDefaultTheme,
   getThemeInterface,
   importCanonicalMap,
+  importFileMap,
   importFileRoutes,
   registerTheme,
   setAtomHoist,
@@ -29,6 +31,47 @@ import type { ModuleNode, PluginOption, UserConfig } from 'vite'
 
 /** CSS entry files emitted by devup-ui: `devup-ui.css`, `devup-ui-3.css`, ... */
 const DEVUP_CSS_FILE_RE = /devup-ui(-\d+)?\.css$/
+
+const SOURCE_DIR_CANDIDATES = ['src', 'app']
+
+/**
+ * Source roots to scan, or an empty list when none of the conventional layouts
+ * are present. Scanning the project root instead would sweep in config files
+ * and other never-transformed modules, so callers skip the scan entirely rather
+ * than guess.
+ */
+function resolveSourceDirs(root: string): string[] {
+  return SOURCE_DIR_CANDIDATES.map((dir) => resolve(root, dir)).filter((dir) =>
+    existsSync(dir),
+  )
+}
+
+/**
+ * Assigns each source file its devup file number up front, ordered by path.
+ *
+ * The engine otherwise hands numbers out on first sight, and the bundler
+ * transforms in parallel, so two identical builds produce different per-file
+ * class prefixes and therefore different CSS *and* JS asset hashes. Seeding
+ * from a sorted scan makes the numbering a pure function of the file paths.
+ * Only the order changes — the count does not — so class prefixes stay exactly
+ * as short as before.
+ *
+ * Vite reports module ids as absolute POSIX-style paths even on Windows, so the
+ * scanned paths are normalized to match the keys `codeExtract` will look up.
+ */
+function seedFileMap(sourceDirs: string[]): void {
+  const sorted = [
+    ...new Set(
+      sourceDirs
+        .flatMap((dir) => listSourceFiles(dir))
+        .map((file) => file.replaceAll('\\', '/')),
+    ),
+  ].sort()
+  if (sorted.length === 0) return
+  const fileMap: Record<string, number> = {}
+  for (const [index, file] of sorted.entries()) fileMap[file] = index
+  importFileMap(fileMap)
+}
 
 /**
  * Names each devup CSS module after its own file, so every module is emitted
@@ -200,6 +243,13 @@ export function DevupUI({
     name: 'devup-ui',
     async configResolved(config) {
       isServe = config?.command === 'serve'
+      const projectRoot = config?.root ?? process.cwd()
+      const sourceDirs = resolveSourceDirs(projectRoot)
+      try {
+        seedFileMap(sourceDirs)
+      } catch {
+        // Best-effort; on failure numbering falls back to arrival order.
+      }
       if (!existsSync(distDir)) await mkdir(distDir, { recursive: true })
       await writeFile(join(distDir, '.gitignore'), '*', 'utf-8')
       await writeDataFiles({
@@ -219,8 +269,10 @@ export function DevupUI({
         atomHoist !== undefined && Number.isFinite(atomHoist) && atomHoist > 0
       if (atomMode) {
         try {
-          const root = config.root ?? process.cwd()
-          const srcDir = resolve(root, 'src')
+          const root = projectRoot
+          // App Router projects keep their sources in `app/`, so a hardcoded
+          // `src/` made the whole pre-pass a silent no-op for them.
+          const srcDir = sourceDirs[0] ?? resolve(root, 'src')
           const tsconfigPath = resolve(root, 'tsconfig.json')
           // C: prefer the bundler's real JS entries; fall back to the heuristic
           // (files with no importer) when input is html-only / unavailable.

--- a/packages/vite-plugin/src/plugin.ts
+++ b/packages/vite-plugin/src/plugin.ts
@@ -16,6 +16,7 @@ import {
 } from '@devup-ui/plugin-utils'
 import {
   codeExtract,
+  exportFileMap,
   getCss,
   getDefaultTheme,
   getThemeInterface,
@@ -59,13 +60,25 @@ function resolveSourceDirs(root: string): string[] {
  * transforms in parallel, so two identical builds produce different per-file
  * class prefixes and therefore different CSS *and* JS asset hashes. Seeding
  * from a sorted scan makes the numbering a pure function of the file paths.
- * Only the order changes — the count does not — so class prefixes stay exactly
- * as short as before.
+ * Every source file now holds a slot, where before only the ones that emitted
+ * styles consumed a number. Prefix length is a step function of the highest
+ * number handed out (1 char up to 26, 2 up to 1025, 3 beyond), so this is free
+ * until a project passes 1026 files under the scanned roots, at which point
+ * prefixes that used to be 2 chars become 3.
  *
  * Vite reports module ids as absolute POSIX-style paths even on Windows, so the
  * scanned paths are normalized to match the keys `codeExtract` will look up.
+ *
+ * `importFileMap` REPLACES the engine's map, and a framework plugin resolves the
+ * config once per environment, so seeding unconditionally would wipe the numbers
+ * already handed to files outside `sourceDirs`: a monorepo sibling, or anything
+ * reached through `include`. The style sheet does not reset with the map, so the
+ * next such file reuses a live number and its atoms overwrite the previous
+ * owner's. Seeding only into an empty map keeps numbering deterministic on the
+ * first pass and stable for every later one.
  */
 function seedFileMap(sourceDirs: string[]): void {
+  if (Object.keys(JSON.parse(exportFileMap())).length > 0) return
   const sorted = [
     ...new Set(
       sourceDirs


### PR DESCRIPTION
> Stacked on #622 — review that first. Base will be retargeted to `main` once #622 lands.

## Problem

Two identical builds of the same source produce different output. devup-ui hands out per-file numbers on first sight:

```rust
// libs/css/src/file_map.rs
let file_num = map.len();
map.insert(filename.to_string(), file_num);
```

The bundler transforms in parallel, so arrival order — and therefore every per-file class prefix — changes run to run. Observed transform order in `benchmark/vinext-devup-ui`: `page, r01, r02, r03, r04, r08, …`.

The result is that every deploy invalidates every cached CSS asset even when nothing changed:

```
build 1: devup-ui-0.BsXjyDW-.css  devup-ui-1.DGmwCf0I.css  devup-ui-10.C7NhwqHF.css
build 2: devup-ui-0.D190fVfN.css  devup-ui-1.-P5lMHHL.css  devup-ui-10.C1fpPAtk.css
```

## Fix

Seed the file map from a sorted scan of the source tree in `configResolved`, before any transform runs, so numbering is a pure function of the file paths:

```ts
importFileMap(Object.fromEntries(sortedSourceFiles.map((f, i) => [f, i])))
```

Reuses `listSourceFiles` from `@devup-ui/plugin-utils` (already used by the atom-hoist pre-pass). Vite reports module ids as absolute POSIX paths even on Windows, so scanned paths are normalized to `/` to match the keys `codeExtract` looks up.

Deliberately **not** a persisted `fileMap.json` like `webpack-plugin`/`next-plugin` use in watch mode. That would make build output a function of leftover disk state rather than of the source — CI starts from a clean checkout (`df/` is gitignored by the plugin's own `df/.gitignore`), so it would not help where reproducibility actually matters, and it rots as files are added or removed.

### Also fixed: the atom-hoist pre-pass was a no-op for App Router projects

`srcDir` was hardcoded to `resolve(root, 'src')`, so any project keeping sources in `app/` silently got no hoisting. Both features now share one source-root resolution (`src/`, then `app/`).

## Size gate

The whole point was to change ordering **without** making class names longer. Prefixes are base-37, so cost is a step function (~37 and ~1400 files), not gradual — the risk is inflating the file *count*, which is why the scan is restricted to conventional source roots and never falls back to scanning the project root (that would sweep in config files and other never-transformed modules).

`benchmark/vinext-devup-ui`, client bundle:

| | before | after |
| --- | --- | --- |
| raw CSS bytes | 14,873 | **14,873** |
| gzip bytes | 7,820 | **7,818** |
| max class prefix length | 1 | **1** |
| CSS files | 22 | 22 |
| identical across 2 cold builds | ❌ | ✅ |

Not one byte larger; gzip is 2 bytes smaller. `maxFileNum` goes 20 → 21 because a style-free `layout.tsx` now occupies a slot — that is free, the prefix stays one character.

Build time did not regress (2.3 s vs 3.3 s warm; the scan is a sorted `readdir` walk that the atom-hoist path already performed).

## Verification

- `benchmark/vinext-devup-ui`: CSS asset hashes now identical across two cold builds
- `apps/vite` (plain Vite 8, `src/` layout): fully reproducible, **CSS and JS**
- 5119 tests pass, `packages/vite-plugin/src/plugin.ts` at 100% function and line coverage, `bun lint` clean

### Residual JS drift in the vinext benchmark is not ours

vinext's JS chunk hashes still move between builds. Removing `DevupUI()` from that config entirely and rebuilding twice shows the same drift, so it originates in vinext/rolldown:

```
run 1 (no DevupUI): index-BLzA-WI8.js  layout-segment-context-CVwlJfdw.js
run 2 (no DevupUI): index-DP5uVSmJ.js  layout-segment-context-8w-Sb3tB.js
```

`apps/vite` — same plugin, no vinext — is stable on both CSS and JS, which is the part devup-ui controls.

## Scope

Contained to `@devup-ui/vite-plugin`. `next`/`webpack`/`rsbuild`/`bun` plugins are untouched and keep their current numbering, so no snapshots move in those packages.
