### PR TITLE
Wait for dynamic import targets before serving base CSS

### DIFF
--- a/.changepacks/changepack_log_kQ7mR2vXpL4tN8sZaB1cD.json
+++ b/.changepacks/changepack_log_kQ7mR2vXpL4tN8sZaB1cD.json
@@ -1,0 +1,1 @@
+{"changes":{"packages/next-plugin/package.json":"Patch","packages/plugin-utils/package.json":"Patch"},"note":"Wait for dynamic() import targets before serving the base CSS so a cold Turbopack build no longer drops every lazily-loaded module's atoms","date":"2026-08-23T00:00:00.000000Z"}

--- a/packages/next-plugin/src/__tests__/plugin.test.ts
+++ b/packages/next-plugin/src/__tests__/plugin.test.ts
@@ -696,6 +696,36 @@ describe('DevupUINextPlugin', () => {
       processOnSpy.mockRestore()
     })
 
+    it('hands the coordinator the full compiled-file set, not the static-only route map', () => {
+      process.env.TURBOPACK = '1'
+      // The base sheet must wait for lazily-loaded modules too, so
+      // expectedBaseFiles comes from computeCompiledFiles (static + dynamic
+      // edges) rather than computeFileRoutes (static edges only). Using the
+      // route map here served the sheet before any dynamic() module extracted.
+      const compiledSpy = spyOn(
+        importGraphModule,
+        'computeCompiledFiles',
+      ).mockReturnValue(['src/app/page.tsx', 'src/lazy/panel.tsx'])
+      const routesSpy = spyOn(
+        importGraphModule,
+        'computeFileRoutes',
+      ).mockReturnValue({ 'src/app/page.tsx': [0] })
+      try {
+        DevupUI({})
+
+        expect(startCoordinatorSpy).toHaveBeenCalledWith(
+          expect.objectContaining({
+            expectedBaseFiles: ['src/app/page.tsx', 'src/lazy/panel.tsx'],
+          }),
+        )
+        // the static-only route map is not consulted outside atom-hoist mode
+        expect(routesSpy).not.toHaveBeenCalled()
+      } finally {
+        compiledSpy.mockRestore()
+        routesSpy.mockRestore()
+      }
+    })
+
     it('does not enable atom hoisting when atomHoist option is unset', () => {
       process.env.TURBOPACK = '1'
       const setAtomHoistSpy = spyOn(wasm, 'setAtomHoist').mockReturnValue(

--- a/packages/next-plugin/src/plugin.ts
+++ b/packages/next-plugin/src/plugin.ts
@@ -9,6 +9,8 @@ import { join, relative, resolve } from 'node:path'
 
 import {
   buildCanonicalMap,
+  buildStaticImportGraph,
+  computeCompiledFiles,
   computeFileRoutes,
   createNodeModulesExcludeRegex,
   createThemeInterfaceArgs,
@@ -139,14 +141,16 @@ export function DevupUI(
     // Hoisted out of the try so the coordinator can receive it for per-bucket
     // completion. Stays `{}` if the best-effort pre-pass fails.
     let canonicalMap: Record<string, string> = {}
-    // Route-reachable runtime files (cwd-relative POSIX) — the deterministic
-    // base-css completion signal handed to the coordinator. Stays `[]` (idle
-    // fallback) when no routes are detected or the pre-pass fails.
+    // Every runtime file the bundler will compile (cwd-relative POSIX) — the
+    // deterministic base-css completion signal handed to the coordinator. Stays
+    // `[]` (idle fallback) when no routes are detected or the pre-pass fails.
     let expectedBaseFiles: string[] = []
     try {
       const srcDir = resolve(process.cwd(), 'src')
       const tsconfigPath = resolve(process.cwd(), 'tsconfig.json')
       const cwd = process.cwd()
+      // One scan+parse of the source tree, shared by all three consumers below.
+      const graph = buildStaticImportGraph(srcDir, tsconfigPath)
       // Atom hoisting owns the shared-chunk decision, so collapse runs WITHOUT
       // the file-level @global hoist (DEVUP_HOIST_V) in atom mode.
       const hoistV = atomMode
@@ -159,16 +163,30 @@ export function DevupUI(
         tsconfigPath,
         cwd,
         hoistV,
+        graph,
       })
       importCanonicalMap(canonicalMap)
       writeFileSync(canonicalMapFile, JSON.stringify(canonicalMap))
 
-      // Route reachability drives BOTH the deterministic base-css wait and (in
-      // atom mode) the hoist plan, so compute it once and share.
-      const fileRoutes = computeFileRoutes({ srcDir, tsconfigPath, cwd })
-      expectedBaseFiles = Object.keys(fileRoutes)
+      // The base sheet must wait for every file the bundler compiles, INCLUDING
+      // the ones only a dynamic `import()` reaches. `computeFileRoutes` stops at
+      // static edges (correct for hoisting, where a lazy chunk is its own unit),
+      // so using its keys here resolved the wait before any `dynamic()` module
+      // had extracted and shipped a sheet missing all of their atoms.
+      expectedBaseFiles = computeCompiledFiles({
+        srcDir,
+        tsconfigPath,
+        cwd,
+        graph,
+      })
 
       if (atomMode) {
+        const fileRoutes = computeFileRoutes({
+          srcDir,
+          tsconfigPath,
+          cwd,
+          graph,
+        })
         // Fold per-file route reach onto the canonical bucket so the keys match
         // the engine's property bucket keys (canonical(filename)).
         const plan = planAtomHoist(canonicalMap, fileRoutes, atomHoist)

--- a/packages/plugin-utils/src/import-graph.test.ts
+++ b/packages/plugin-utils/src/import-graph.test.ts
@@ -14,6 +14,7 @@ import {
   __setOxcParserForTest,
   buildCanonicalMap,
   buildStaticImportGraph,
+  computeCompiledFiles,
   computeFileReach,
   computeFileRoutes,
   planAtomHoist,
@@ -711,6 +712,115 @@ describe('computeFileRoutes', () => {
 
     expect(routes['src/orphan.tsx']).toBeUndefined()
     expect(routes['src/app/a/page.tsx']).toEqual([0])
+  })
+})
+
+describe('computeCompiledFiles', () => {
+  let tempRoot: string
+  let cwd: string
+  let srcDir: string
+
+  beforeEach(() => {
+    tempRoot = mkdtempSync(join(tmpdir(), 'devup-ui-compiled-files-'))
+    cwd = join(tempRoot, 'project')
+    srcDir = join(cwd, 'src')
+    mkdirSync(srcDir, { recursive: true })
+  })
+
+  afterEach(() => {
+    rmSync(tempRoot, { recursive: true, force: true })
+  })
+
+  function writeFixture(path: string, code: string): void {
+    const filePath = join(cwd, path)
+    mkdirSync(dirname(filePath), { recursive: true })
+    writeFileSync(filePath, code)
+  }
+
+  it('includes dynamic-import targets and their static closure', () => {
+    // The bundler compiles `panel` (and everything it statically imports) even
+    // though only a dynamic import reaches it, so the base sheet must wait for
+    // them. `computeFileRoutes` deliberately stops at static edges, which is
+    // why the base-css wait needs its own, wider file set.
+    writeFixture('src/app/page.tsx', "import './shell'\n")
+    writeFixture(
+      'src/app/shell.tsx',
+      "export const load = () => import('../lazy/panel')\n",
+    )
+    writeFixture('src/lazy/panel.tsx', "import './panel-body'\n")
+    writeFixture('src/lazy/panel-body.tsx', 'export const B = 1\n')
+
+    const compiled = computeCompiledFiles({ cwd, srcDir })
+
+    expect(compiled).toContain('src/app/page.tsx')
+    expect(compiled).toContain('src/app/shell.tsx')
+    expect(compiled).toContain('src/lazy/panel.tsx')
+    expect(compiled).toContain('src/lazy/panel-body.tsx')
+    // the static-only route map stops at the dynamic boundary
+    expect(Object.keys(computeFileRoutes({ cwd, srcDir }))).not.toContain(
+      'src/lazy/panel.tsx',
+    )
+  })
+
+  it('follows dynamic imports nested behind another dynamic import', () => {
+    writeFixture(
+      'src/app/page.tsx',
+      "export const load = () => import('../first')\n",
+    )
+    writeFixture(
+      'src/first.tsx',
+      "export const load = () => import('./second')\n",
+    )
+    writeFixture('src/second.tsx', 'export const S = 1\n')
+
+    const compiled = computeCompiledFiles({ cwd, srcDir })
+
+    expect(compiled).toContain('src/first.tsx')
+    expect(compiled).toContain('src/second.tsx')
+  })
+
+  it('includes files reached only through an ancestor route shell', () => {
+    writeFixture(
+      'src/app/layout.tsx',
+      "export const l = () => import('../m')\n",
+    )
+    writeFixture('src/m.tsx', 'export const M = 1\n')
+    writeFixture('src/app/a/page.tsx', 'export const A = 1\n')
+
+    expect(computeCompiledFiles({ cwd, srcDir })).toContain('src/m.tsx')
+  })
+
+  it('omits files reachable from no leaf route', () => {
+    writeFixture('src/app/a/page.tsx', 'export const A = 1\n')
+    writeFixture('src/orphan.tsx', 'export const Orphan = 1\n')
+
+    const compiled = computeCompiledFiles({ cwd, srcDir })
+
+    expect(compiled).toContain('src/app/a/page.tsx')
+    expect(compiled).not.toContain('src/orphan.tsx')
+  })
+
+  it('returns an empty list when no leaf route exists', () => {
+    writeFixture('src/index.tsx', "import './a'\n")
+    writeFixture('src/a.tsx', 'export const A = 1\n')
+
+    // Empty keeps the coordinator on its idle fallback instead of blocking on
+    // a file set that never completes.
+    expect(computeCompiledFiles({ cwd, srcDir })).toEqual([])
+  })
+
+  it('reuses a prebuilt graph', () => {
+    writeFixture(
+      'src/app/page.tsx',
+      "export const l = () => import('../lazy')\n",
+    )
+    writeFixture('src/lazy.tsx', 'export const L = 1\n')
+
+    const graph = buildStaticImportGraph(srcDir)
+
+    expect(computeCompiledFiles({ cwd, srcDir, graph })).toEqual(
+      computeCompiledFiles({ cwd, srcDir }),
+    )
   })
 })
 

--- a/packages/plugin-utils/src/import-graph.ts
+++ b/packages/plugin-utils/src/import-graph.ts
@@ -93,6 +93,13 @@ export interface StaticImportGraph {
   staticImporters: Map<string, Set<string>>
   /** files loaded via dynamic `import()` somewhere under `srcDir`. */
   dynamicTargets: Set<string>
+  /**
+   * file -> files it loads via dynamic `import()` (within `srcDir`). The
+   * per-importer counterpart of `dynamicTargets`: reachability needs to know
+   * WHICH file lazy-loads what, otherwise a dynamic target whose only importer
+   * is itself unreachable would be treated as compiled.
+   */
+  dynamicImports: Map<string, Set<string>>
 }
 
 /**
@@ -116,11 +123,13 @@ export function buildStaticImportGraph(
   }
   const staticImporters = new Map<string, Set<string>>()
   const staticImports = new Map<string, Set<string>>()
+  const dynamicImports = new Map<string, Set<string>>()
   const dynamicTargets = new Set<string>()
 
   for (const file of files) {
     staticImporters.set(file, new Set())
     staticImports.set(file, new Set())
+    dynamicImports.set(file, new Set())
   }
 
   for (const file of files) {
@@ -130,6 +139,7 @@ export function buildStaticImportGraph(
       if (!target) continue
       if (importRef.kind === 'dynamic') {
         dynamicTargets.add(target)
+        dynamicImports.get(file)?.add(target)
         continue
       }
       staticImporters.get(target)?.add(file)
@@ -137,7 +147,14 @@ export function buildStaticImportGraph(
     }
   }
 
-  return { files, fileSet, staticImports, staticImporters, dynamicTargets }
+  return {
+    files,
+    fileSet,
+    staticImports,
+    staticImporters,
+    dynamicTargets,
+    dynamicImports,
+  }
 }
 
 export function buildCanonicalMap(
@@ -240,6 +257,64 @@ export function computeFileRoutes(
   })
 
   return fileRoutes
+}
+
+export interface ComputeCompiledFilesOptions {
+  srcDir: string
+  tsconfigPath?: string
+  cwd: string
+  /** pre-built graph from `buildStaticImportGraph` to skip the file scan. */
+  graph?: StaticImportGraph
+}
+
+/**
+ * Every source file the bundler will compile for the app's routes: the closure
+ * of all leaf routes (plus their ancestor route shells) over BOTH static and
+ * dynamic `import()` edges.
+ *
+ * This is deliberately WIDER than `computeFileRoutes`, whose closure stops at
+ * static edges because a lazily-loaded file belongs to its own chunk for
+ * hoisting purposes. Completion tracking needs the opposite guarantee: a file
+ * behind `dynamic(() => import(...))` is still compiled, still POSTs
+ * `/extract`, and still contributes atoms to the shared sheet — so a base-CSS
+ * wait built from the static-only set resolves BEFORE those atoms exist and
+ * serves a sheet missing every lazily-loaded component's styles.
+ *
+ * Keys are POSIX paths relative to `cwd`, matching the extraction filename the
+ * loader posts. Returns a sorted array (deterministic across runs). Empty when
+ * no leaf route is detected, which keeps callers on their idle fallback rather
+ * than blocking on a set that can never complete.
+ */
+export function computeCompiledFiles(
+  opts: ComputeCompiledFilesOptions,
+): string[] {
+  const cwd = resolve(opts.cwd)
+  const srcDir = resolve(opts.srcDir)
+  const { files, staticImports, dynamicImports } =
+    opts.graph ?? buildStaticImportGraph(srcDir, opts.tsconfigPath)
+
+  const allImports = new Map<string, Set<string>>()
+  for (const file of files) {
+    const edges = new Set(staticImports.get(file))
+    for (const target of dynamicImports.get(file) ?? []) edges.add(target)
+    allImports.set(file, edges)
+  }
+
+  const routeShellFilesByDir = getRouteShellFilesByDir(files, srcDir)
+  const compiled = new Set<string>()
+  for (const file of files) {
+    if (!leafRouteFileRegex.test(toPosixRelative(srcDir, file))) continue
+    for (const reached of getLeafRouteClosure(
+      file,
+      srcDir,
+      allImports,
+      routeShellFilesByDir,
+    )) {
+      compiled.add(reached)
+    }
+  }
+
+  return [...compiled].map((file) => toPosixRelative(cwd, file)).sort()
 }
 
 export interface ComputeFileReachOptions {

--- a/packages/plugin-utils/src/index.ts
+++ b/packages/plugin-utils/src/index.ts
@@ -3,6 +3,8 @@ export {
   buildCanonicalMap,
   type BuildCanonicalMapOptions,
   buildStaticImportGraph,
+  computeCompiledFiles,
+  type ComputeCompiledFilesOptions,
   computeFileReach,
   type ComputeFileReachOptions,
   computeFileRoutes,


### PR DESCRIPTION
## Problem

With `singleCss: true` on Turbopack, a **cold** production build ships a `devup-ui.css` that is missing the atoms of every component reached only through `dynamic(() => import(...))`. A warm rebuild hides it, because `df/` already holds the sheet from the previous run — so this mostly bites fresh CI checkouts and first-time clones.

`plugin.ts` built the coordinator's completion signal from the route map:

```ts
const fileRoutes = computeFileRoutes({ srcDir, tsconfigPath, cwd })
expectedBaseFiles = Object.keys(fileRoutes)
```

`computeFileRoutes` walks `staticImports` only — `buildStaticImportGraph` deliberately diverts dynamic `import()` edges into `dynamicTargets` and never adds them to the closure. So `expectedBaseFiles` under-approximates what the bundler actually compiles, `waitForBase()` reports the base sheet complete while the lazy modules are still queued, and `/css` returns early. Turbopack bundles that single response; there is no second chance.

Measured on a Next 16 app with 6 `dynamic()` panels:

```
source files under src:       81
expectedBaseFiles (before):   55   <- 14 real components missing
```

Every missing file was a `dynamic()` target or part of one's static closure, and every missing CSS declaration belonged to exactly those files.

## Fix

- Add `computeCompiledFiles()` — the closure of all leaf routes (plus ancestor route shells) over **static ∪ dynamic** edges. This is the set the bundler compiles and therefore the set the base sheet must wait for.
- `computeFileRoutes` is left untouched. Its static-only closure is correct for atom hoisting, where a lazy chunk is legitimately its own unit; the two consumers just need different sets.
- Track dynamic edges **per importer** (`StaticImportGraph.dynamicImports`) rather than relying on the flat `dynamicTargets`. Precision matters here: a dynamic target whose only importer is unreachable must not enter the wait set, or `baseFilesComplete()` never satisfies and every build stalls until the 10s quiet fallback.
- `plugin.ts` now builds the import graph **once** and shares it with all three consumers. It previously scanned and parsed the whole source tree twice (`buildCanonicalMap` + `computeFileRoutes` each rebuilt it), even though the `graph` option already existed for this.

## Verification

Real-app cold build, before vs after, comparing CSS **declarations** with the generated class token normalised (immune to class renaming and minifier shortenings such as `translateX(-50%)` → `translate(-50%)`):

```
expectedBaseFiles            55  ->  69     (0 files dropped, no test fixtures pulled in)
declarations only WITH fix   45             (all of them dynamic()-component styles)
declarations only WITHOUT    6              (same declarations, renamed CSS vars — 1:1 pairs)
```

The 45 recovered declarations are exactly the lazily-loaded components' styles: the markdown ruleset of the document preview, the DOCX fallback's `.subird-docx` / `.subird-docx-wrapper` rules, `object-fit:contain`, the archive/memory/skill modal borders, and so on.

## Tests

- 6 new `computeCompiledFiles` cases: dynamic target + its static closure, nested dynamic behind dynamic, reachable only via an ancestor route shell, orphan exclusion, empty result when no leaf route exists (keeps callers on the idle fallback), prebuilt-graph reuse.
- 1 new `next-plugin` case asserting the coordinator receives `computeCompiledFiles` output and that the static-only route map is not consulted outside atom-hoist mode.
- Confirmed the tests actually catch the bug: reverting the dynamic edges turns 3 of them red.
- `bun test` 5098 pass / 0 fail. `plugin-utils/src/import-graph.ts` and `next-plugin/src/plugin.ts` both at 100% line and function coverage. ESLint clean. No Rust touched.

## Note (separate from this change)

`bun test` on a fresh clone fails with `Cannot find module '<root>/df/devup-ui/devup-ui.css'`: the bun plugin's setup creates the `df/devup-ui` **directory** but never the `devup-ui.css` **file** that the transformed code imports. Creating an empty file at that path makes the suite pass. Not fixed here to keep this PR to one concern — happy to send it separately if useful.
