### PR TITLE
Fail the build when a package's dist entry point is a broken stub

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -100,6 +100,8 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       - run: bun install
       - run: bun run build
+      - name: Verify built package entry points
+        run: bun run verify:dist
       - run: |
           bun run lint
           # rust coverage issue

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "test:e2e:update": "bunx playwright test --update-snapshots",
     "build": "bun run --filter @devup-ui/wasm --filter @devup-ui/plugin-utils build && bun run --filter @devup-ui/react --filter @devup-ui/webpack-plugin build && bun run --filter @devup-ui/eslint-plugin --filter @devup-ui/vite-plugin --filter @devup-ui/next-plugin --filter @devup-ui/rsbuild-plugin --filter @devup-ui/bun-plugin --filter @devup-ui/components --filter @devup-ui/reset-css build",
     "dev": "bun run --filter '*' dev",
+    "verify:dist": "bun verify-dist.ts",
     "benchmark": "bun benchmark.js",
     "prepare": "husky",
     "changepacks": "bunx @changepacks/cli",

--- a/verify-dist.ts
+++ b/verify-dist.ts
@@ -1,0 +1,97 @@
+import { existsSync } from 'node:fs'
+import { readdir, readFile } from 'node:fs/promises'
+import { join, resolve } from 'node:path'
+import { pathToFileURL } from 'node:url'
+
+// A bundler that drops a module but keeps its re-export clause produces a file
+// that still *builds* (exit 0) and only fails when something loads it. Bun 1.4.0
+// did exactly that for a barrel entry whose package declared
+// `sideEffects: false`, shrinking `dist/index.mjs` to a 22-byte stub. Nothing in
+// `bun run build` catches it, so a broken package can reach npm. Loading every
+// declared entry and touching every export turns that silence into a failure.
+
+// Thrown by devup-ui's compile-only stubs. A package like @devup-ui/reset-css
+// calls one at module scope, so raising it proves the entry executed real code
+// rather than collapsing into a stub — which is exactly what this check asks.
+const COMPILE_ONLY_SENTINEL = 'Cannot run on the runtime'
+
+interface PackageManifest {
+  name?: string
+  main?: string
+  module?: string
+  exports?: unknown
+  files?: string[]
+}
+
+function collectEntries(node: unknown, found: Set<string>): void {
+  if (typeof node === 'string') {
+    if (node.startsWith('./dist/') && /\.(c|m)?js$/.test(node)) found.add(node)
+    return
+  }
+  if (Array.isArray(node)) {
+    for (const child of node) collectEntries(child, found)
+    return
+  }
+  if (node && typeof node === 'object') {
+    for (const child of Object.values(node)) collectEntries(child, found)
+  }
+}
+
+async function verifyPackage(pkgDir: string): Promise<string[]> {
+  const manifestPath = join(pkgDir, 'package.json')
+  if (!existsSync(manifestPath)) return []
+  const manifest: PackageManifest = JSON.parse(
+    await readFile(manifestPath, 'utf-8'),
+  )
+  if (!manifest.files?.includes('dist')) return []
+
+  const entries = new Set<string>()
+  collectEntries(manifest.main, entries)
+  collectEntries(manifest.module, entries)
+  collectEntries(manifest.exports, entries)
+
+  const failures: string[] = []
+  for (const entry of [...entries].sort()) {
+    const entryPath = resolve(pkgDir, entry)
+    const label = `${manifest.name} ${entry}`
+    if (!existsSync(entryPath)) {
+      failures.push(`${label}: declared but missing on disk`)
+      continue
+    }
+    try {
+      const loaded: Record<string, unknown> = await import(
+        pathToFileURL(entryPath).href
+      )
+      const keys = Object.keys(loaded)
+      if (keys.length === 0) {
+        failures.push(`${label}: loaded with zero exports`)
+        continue
+      }
+      // Broken CJS output keeps the export getters and only throws on access.
+      for (const key of keys) void loaded[key]
+    } catch (error) {
+      const message = (error as Error).message
+      if (!message.includes(COMPILE_ONLY_SENTINEL)) {
+        failures.push(`${label}: ${message}`)
+      }
+    }
+  }
+  return failures
+}
+
+const packagesDir = resolve(import.meta.dir, 'packages')
+const dirs = await readdir(packagesDir, { withFileTypes: true })
+const failures = (
+  await Promise.all(
+    dirs
+      .filter((d) => d.isDirectory())
+      .map((d) => verifyPackage(join(packagesDir, d.name))),
+  )
+).flat()
+
+if (failures.length > 0) {
+  console.error(`verify-dist: ${failures.length} broken entry point(s)`)
+  for (const failure of failures) console.error(`  - ${failure}`)
+  process.exit(1)
+}
+console.info('verify-dist: all declared dist entry points load and export')


### PR DESCRIPTION
## Problem

The bun 1.4 tree-shaking bug fixed in a9f0114f was **silent**. `bun run build` exited 0 while emitting `export {...}` clauses that named bindings the bundler had already dropped:

```
packages/plugin-utils/dist/index.mjs    10,948 -> 356 bytes
packages/next-plugin/dist/index.mjs      7,564 ->  22 bytes
packages/vite-plugin/dist/index.mjs      3,838 ->  22 bytes
packages/webpack-plugin/dist/index.mjs   4,246 ->  35 bytes
packages/rsbuild-plugin/dist/index.mjs   2,887 ->  22 bytes
```

Nothing between `bun run build` and `npm publish` inspects that output. The test suite noticed only incidentally — bun's test preload imports `@devup-ui/plugin-utils`, so a broken barrel took down all 60 test files. A package whose entry is *not* on that preload path could have shipped as a stub.

`bun-plugin` shows why size alone is not a signal: its ESM entry stayed at exactly 1,409 bytes while ending in `export{K as plugin}` with `K` never declared.

## Fix

`bun run verify:dist` loads every entry point each package declares through `main`, `module` and `exports`, then reads every export. Wired into CI right after `bun run build`, before lint and tests.

Two details that are not obvious from the code:

- **Exports are read, not just imported.** Broken CJS output keeps its export getters intact and throws only on property access, so `import()` alone returns a module that looks fine.
- **`Cannot run on the runtime` counts as a pass.** `@devup-ui/reset-css` calls a compile-only devup API at module scope. Raising that sentinel proves the entry executed real code rather than collapsing into a stub, which is exactly what this check asks.

Scope is limited to packages that declare `files: ["dist"]`, so it follows what actually gets published.

## Verification

Checked against the regression it exists for, on current `main` with bun 1.4.0:

| state | result |
| --- | --- |
| `main` as-is | `verify-dist: all declared dist entry points load and export`, exit 0 |
| `sideEffects: false` restored on **plugin-utils only** | `plugin-utils/dist/index.mjs` -> 410 bytes, **9 broken entry points, exit 1** |

The single-package regression is caught across all nine dependent entry points, not just the one that was changed.

`bun test` 5118 pass / 0 fail, `cargo fmt`/`clippy` clean, ESLint clean.

No changepack: this touches only the root `package.json` script, the workflow, and a new root-level script — no published package changes.
