### PR TITLE
Give the publish job full history so changepacks can release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -59,6 +59,12 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v7
+        with:
+          # changepacks diffs HEAD against the previous release commit. The
+          # default shallow fetch grafts away every parent, so that lookup dies
+          # with "Could not find a merge-base" and the release never publishes.
+          fetch-depth: 0
+          fetch-tags: true
 
       - uses: actions-rust-lang/setup-rust-toolchain@v1
 

--- a/bun.lock
+++ b/bun.lock
@@ -425,7 +425,7 @@
     },
     "packages/bun-plugin": {
       "name": "@devup-ui/bun-plugin",
-      "version": "1.0.10",
+      "version": "1.0.12",
       "dependencies": {
         "@devup-ui/plugin-utils": "workspace:^",
         "@devup-ui/wasm": "workspace:^",
@@ -440,7 +440,7 @@
     },
     "packages/components": {
       "name": "@devup-ui/components",
-      "version": "0.1.47",
+      "version": "0.1.49",
       "dependencies": {
         "@devup-ui/react": "workspace:^",
         "clsx": "^2.1",
@@ -483,7 +483,7 @@
     },
     "packages/next-plugin": {
       "name": "@devup-ui/next-plugin",
-      "version": "1.0.78",
+      "version": "1.0.80",
       "dependencies": {
         "@devup-ui/plugin-utils": "workspace:^",
         "@devup-ui/wasm": "workspace:^",
@@ -501,7 +501,7 @@
     },
     "packages/plugin-utils": {
       "name": "@devup-ui/plugin-utils",
-      "version": "1.0.8",
+      "version": "1.0.10",
       "devDependencies": {
         "typescript": "^7.0",
       },
@@ -542,7 +542,7 @@
     },
     "packages/rsbuild-plugin": {
       "name": "@devup-ui/rsbuild-plugin",
-      "version": "1.0.56",
+      "version": "1.0.58",
       "dependencies": {
         "@devup-ui/plugin-utils": "workspace:^",
         "@devup-ui/wasm": "workspace:^",
@@ -558,7 +558,7 @@
     },
     "packages/vite-plugin": {
       "name": "@devup-ui/vite-plugin",
-      "version": "1.0.61",
+      "version": "1.0.63",
       "dependencies": {
         "@devup-ui/plugin-utils": "workspace:^",
         "@devup-ui/wasm": "workspace:^",
@@ -573,7 +573,7 @@
     },
     "packages/webpack-plugin": {
       "name": "@devup-ui/webpack-plugin",
-      "version": "1.0.61",
+      "version": "1.0.63",
       "dependencies": {
         "@devup-ui/plugin-utils": "workspace:^",
         "@devup-ui/wasm": "workspace:^",


### PR DESCRIPTION
## Problem

**The 1.0.63 release did not reach npm.** `main` carries the bumped versions from #625, npm still serves the previous set:

| package | main | npm |
| --- | --- | --- |
| @devup-ui/vite-plugin | 1.0.63 | 1.0.62 |
| @devup-ui/next-plugin | 1.0.80 | 1.0.79 |
| @devup-ui/plugin-utils | 1.0.10 | 1.0.9 |
| @devup-ui/bun-plugin | 1.0.12 | 1.0.11 |
| @devup-ui/components | 0.1.49 | 0.1.48 |
| @devup-ui/rsbuild-plugin | 1.0.58 | 1.0.57 |
| @devup-ui/webpack-plugin | 1.0.63 | 1.0.62 |

[Run 32623566503](https://github.com/dev-five-git/devup-ui/actions/runs/32623566503) passed build, `verify:dist`, lint, the full test suite and both e2e passes, then died on the last step:

```
##[error]Error: changepacks check failed: Error: Could not find a merge-base
between commits 87ca1e992c9945f7ca970c249037b827e9c87f3e
and 82397aa22d99b7647e458aea822c89949a566038
```

## Root cause

`actions/checkout` fetches shallow by default. From the same run's Checkout step:

```
git -c protocol.version=2 fetch --no-tags --prune --no-recurse-submodules --depth=1
  origin +87ca1e992c9945f7ca970c249037b827e9c87f3e:refs/remotes/origin/main
```

`--depth=1` grafts away every parent, so the working repo holds exactly one commit with no ancestry. changepacks diffs `HEAD` against the previous release commit to decide what to publish; with both ends present but no reachable common ancestor, that lookup fails and the release aborts.

It is the last step in the job, so everything upstream of it reports green and the run looks healthy until you open the log.

## Fix

`fetch-depth: 0` plus `fetch-tags` on the publish job's checkout — changepacks reads the release tags as well as the history. The benchmark job does not run changepacks and stays shallow.

## Effect

Merging this triggers `publish` on `main` again, now with full history, which publishes the seven versions listed above and closes the gap between the repo and npm.

## Also in this commit

`bun.lock` picks up the workspace versions from #625 (`1.0.10` -> `1.0.12` and friends). The changepacks bot bumps `package.json` but not the lockfile, so `main` was internally inconsistent. Not required for the fix; `bun install` regenerates it either way.
