### PR TITLE
Add plugin-configured custom shorthands

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,40 @@ const textExample = <Text color="$primary" />
 const boxExample = <Box typography="$heading" />
 ```
 
+**Custom shorthands:**
+
+Define reusable prop aliases in the build plugin options. Property names may
+use camelCase or CSS kebab-case, and one shorthand can target multiple
+properties.
+
+```ts
+// vite.config.ts
+export default defineConfig({
+  plugins: [
+    DevupUI({
+      shorthands: {
+        insetX: ['left', 'right'],
+        scrollMarginX: ['scrollMarginLeft', 'scrollMarginRight'],
+      },
+    }),
+  ],
+})
+```
+
+The plugin adds configured names to the generated declaration file, so they are
+available as type-safe component props and selector properties after the plugin
+has run. Restart the build after changing this option so `df/theme.d.ts` is
+regenerated. The same value is applied to every target property.
+
+If your `tsconfig.json` limits `include` to `src`, also include `df/*.d.ts` (or
+the matching custom `distDir`) so the generated augmentation is loaded.
+
+```tsx
+const pinned = <Box insetX={0} />
+const responsive = <Box insetX={[0, null, 'auto']} />
+const interactive = <Box _hover={{ insetX: 4 }} />
+```
+
 **Responsive + Pseudo selectors together:**
 
 ```tsx

--- a/README_ko.md
+++ b/README_ko.md
@@ -179,6 +179,38 @@ const textExample = <Text color="$primary" />
 const boxExample = <Box typography="$heading" />
 ```
 
+**사용자 정의 shorthand:**
+
+Shorthand는 디자인 토큰이 아니므로 `devup.json`이 아니라 빌드 플러그인
+옵션에서 정의합니다. 각 shorthand는 하나의 prop 값을 여러 CSS 속성에
+동일하게 적용합니다.
+
+```ts
+// vite.config.ts
+export default defineConfig({
+  plugins: [
+    DevupUI({
+      shorthands: {
+        insetX: ['left', 'right'],
+        scrollMarginX: ['scrollMarginLeft', 'scrollMarginRight'],
+      },
+    }),
+  ],
+})
+```
+
+플러그인이 실행되면 기본 경로인 `df/theme.d.ts`에 선언이 생성되어 일반
+prop, 반응형 배열, 가상 선택자, 사용자 정의 selector에서 이름과 값 타입이
+자동 완성됩니다. 설정을 바꾼 뒤에는 빌드 도구를 재시작해야 합니다.
+`tsconfig.json`의 `include`가 `src`로 제한되어 있다면 `df/*.d.ts`도
+포함하세요. `distDir`를 바꿨다면 해당 경로를 포함하면 됩니다.
+
+```tsx
+const pinned = <Box insetX={0} />
+const responsive = <Box insetX={[0, null, 'auto']} />
+const interactive = <Box _hover={{ insetX: 4 }} />
+```
+
 **반응형 + 가상 선택자 동시 사용:**
 
 ```tsx

--- a/apps/landing/src/app/(detail)/docs/LeftMenu.tsx
+++ b/apps/landing/src/app/(detail)/docs/LeftMenu.tsx
@@ -97,6 +97,10 @@ export function LeftMenu() {
             children: 'Style Props',
           },
           {
+            to: '/docs/api/custom-shorthands',
+            children: 'Custom Shorthands',
+          },
+          {
             to: '/docs/api/selector',
             children: 'Selector',
           },

--- a/apps/landing/src/app/(detail)/docs/api/custom-shorthands/page.mdx
+++ b/apps/landing/src/app/(detail)/docs/api/custom-shorthands/page.mdx
@@ -1,0 +1,186 @@
+export const metadata = {
+  title: 'Custom Shorthands',
+  description:
+    'Configure build-time Devup UI prop aliases with generated TypeScript completion.',
+  alternates: {
+    canonical: '/docs/api/custom-shorthands',
+  },
+  openGraph: {
+    title: 'Devup UI - Custom Shorthands',
+    description:
+      'Configure build-time Devup UI prop aliases with generated TypeScript completion.',
+    url: '/docs/api/custom-shorthands',
+    siteName: 'Devup UI',
+  },
+}
+
+# Custom Shorthands
+
+Custom shorthands define build-time prop aliases that apply one value to
+multiple CSS properties. They are plugin options, not design tokens, so define
+them in your bundler configuration rather than `devup.json`.
+
+```ts
+DevupUI({
+  shorthands: {
+    insetX: ['left', 'right'],
+    scrollMarginX: ['scrollMarginLeft', 'scrollMarginRight'],
+  },
+})
+```
+
+```tsx
+const pinned = <Box insetX={0} />
+const responsive = <Box insetX={[0, null, 'auto']} />
+const interactive = <Box _hover={{ insetX: 4 }} />
+const nested = <Box selectors={{ '& > *': { insetX: 2 } }} />
+```
+
+For `insetX={4}`, both `left` and `right` receive the same resolved value. Every
+target follows the existing Devup UI value rules.
+
+## Plugin Configuration
+
+### Vite
+
+```ts
+import { DevupUI } from '@devup-ui/vite-plugin'
+import { defineConfig } from 'vite'
+
+export default defineConfig({
+  plugins: [
+    DevupUI({
+      shorthands: {
+        insetX: ['left', 'right'],
+      },
+    }),
+  ],
+})
+```
+
+### Next.js
+
+```ts
+import { DevupUI } from '@devup-ui/next-plugin'
+
+const nextConfig = {}
+
+export default DevupUI(nextConfig, {
+  shorthands: {
+    insetX: ['left', 'right'],
+  },
+})
+```
+
+The second argument is shared by the Webpack and Turbopack paths.
+
+### Webpack
+
+```ts
+import { DevupUIWebpackPlugin } from '@devup-ui/webpack-plugin'
+
+export default {
+  plugins: [
+    new DevupUIWebpackPlugin({
+      shorthands: {
+        insetX: ['left', 'right'],
+      },
+    }),
+  ],
+}
+```
+
+### Rsbuild
+
+```ts
+import { DevupUI } from '@devup-ui/rsbuild-plugin'
+import { defineConfig } from '@rsbuild/core'
+
+export default defineConfig({
+  plugins: [
+    DevupUI({
+      shorthands: {
+        insetX: ['left', 'right'],
+      },
+    }),
+  ],
+})
+```
+
+### Bun
+
+Use a local preload module when options are required:
+
+```toml
+# bunfig.toml
+[test]
+preload = ["./devup-ui.preload.ts"]
+```
+
+```ts
+// devup-ui.preload.ts
+import { register } from '@devup-ui/bun-plugin/register'
+
+await register({
+  shorthands: {
+    insetX: ['left', 'right'],
+  },
+})
+```
+
+## Property Names
+
+Target properties may use either camelCase or CSS kebab-case:
+
+```ts
+DevupUI({
+  shorthands: {
+    scrollMarginX: ['scrollMarginLeft', 'scroll-margin-right'],
+  },
+})
+```
+
+Targets can also use built-in Devup UI shorthands. For example, `py` expands
+to both `padding-top` and `padding-bottom`:
+
+```ts
+DevupUI({
+  shorthands: {
+    sectionSpacing: ['py', 'gap'],
+  },
+})
+```
+
+## Type Completion
+
+When the plugin starts, it writes the configured prop names to
+`<distDir>/theme.d.ts` (`df/theme.d.ts` by default). The declaration augments
+`DevupProps`, so completion and type checking work for:
+
+- Component props such as `<Box insetX={0} />`
+- Responsive arrays such as `insetX={[0, null, 'auto']}`
+- Pseudo selectors such as `_hover={{ insetX: 4 }}`
+- Custom selectors such as `selectors={{ '& > *': { insetX: 2 } }}`
+
+If `tsconfig.json` limits `include` to your source directory, include the
+generated declaration as well:
+
+```json
+{
+  "include": ["src", "df/*.d.ts"]
+}
+```
+
+Restart the build tool after changing `shorthands`, because bundler
+configuration changes do not use the `devup.json` hot-reload path.
+
+## Design Tokens vs. Shorthands
+
+Use `devup.json` for values that belong to the design system, such as colors,
+typography, lengths, and shadows. Use plugin `shorthands` for prop vocabulary
+and extraction behavior.
+
+```tsx
+// $contentX is a design-token value; insetX is a custom prop alias.
+const content = <Box insetX="$contentX" />
+```

--- a/apps/landing/src/app/(detail)/docs/core-concepts/type-inference-system/page.mdx
+++ b/apps/landing/src/app/(detail)/docs/core-concepts/type-inference-system/page.mdx
@@ -37,3 +37,7 @@ Devup UI's type inference system provides several key benefits:
 - **Standards compliance** – Types are always aligned with official CSS specifications, ensuring accuracy and consistency across all CSS standards.
 
 This type inference system is automatic, reliable, and future-ready, allowing developers to focus on design and logic rather than manual type management.
+
+Build plugins also generate module augmentation for configured prop aliases.
+See [Custom Shorthands](/docs/api/custom-shorthands) for configuration and
+generated-type setup.

--- a/apps/landing/src/app/(detail)/docs/devup/devup-json/page.mdx
+++ b/apps/landing/src/app/(detail)/docs/devup/devup-json/page.mdx
@@ -9,6 +9,10 @@ export const metadata = {
 
 The `devup.json` file is the configuration file for your Devup UI theme. Create it at the root of your project to define colors, typography, length, shadow, and other design tokens.
 
+Custom prop shorthands are extraction behavior rather than design tokens, so
+they do not belong in this file. Configure them in the build plugin instead;
+see [Custom Shorthands](/docs/api/custom-shorthands).
+
 ## Basic Structure
 
 ```json

--- a/bindings/devup-ui-wasm/src/lib.rs
+++ b/bindings/devup-ui-wasm/src/lib.rs
@@ -6,7 +6,7 @@ use extractor::extract_style::extract_style_value::ExtractStyleValue;
 use extractor::{ExtractOption, ImportAlias, extract, has_devup_ui};
 use rustc_hash::FxHashSet;
 use sheet::StyleSheet;
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::fmt::Display;
 use std::sync::{LazyLock, Mutex};
 use wasm_bindgen::prelude::*;
@@ -399,6 +399,19 @@ pub fn register_theme(theme_object: JsValue) -> Result<(), JsValue> {
     let theme: sheet::theme::Theme =
         serde_wasm_bindgen::from_value(theme_object).map_err(js_error)?;
     register_theme_internal(theme);
+    Ok(())
+}
+
+/// Internal function to register custom style-property shorthands.
+pub fn register_shorthands_internal(shorthands: BTreeMap<String, Vec<String>>) {
+    css::set_custom_shorthands(shorthands);
+}
+
+#[wasm_bindgen(js_name = "registerShorthands")]
+#[cfg(not(tarpaulin_include))]
+pub fn register_shorthands(shorthands: JsValue) -> Result<(), JsValue> {
+    let shorthands = serde_wasm_bindgen::from_value(shorthands).map_err(js_error)?;
+    register_shorthands_internal(shorthands);
     Ok(())
 }
 
@@ -1150,6 +1163,7 @@ mod tests {
     #[test]
     #[serial]
     fn test_get_theme_interface() {
+        register_shorthands_internal(BTreeMap::new());
         let sheet = StyleSheet::default();
         assert_eq!(
             sheet.create_interface(
@@ -1168,6 +1182,10 @@ mod tests {
         color_theme.add_color("primary", "#000");
         theme.add_color_theme("dark", color_theme);
         GLOBAL_STYLE_SHEET.lock().unwrap().set_theme(theme);
+        register_shorthands_internal(BTreeMap::from([(
+            "insetX".to_string(),
+            vec!["left".to_string(), "right".to_string()],
+        )]));
         assert_eq!(
             get_theme_interface(
                 "package",
@@ -1177,10 +1195,11 @@ mod tests {
                 "ShadowsInterface",
                 "ThemeInterface"
             ),
-            "import \"package\";declare module \"package\"{interface ColorInterface{$primary:null}interface TypographyInterface{}interface LengthInterface{}interface ShadowsInterface{}interface ThemeInterface{dark:null}}"
+            "import \"package\";import type{DevupProps}from\"package\";declare module \"package\"{interface ColorInterface{$primary:null}interface TypographyInterface{}interface LengthInterface{}interface ShadowsInterface{}interface DevupCustomShorthands{insetX?:DevupProps[\"w\"]}interface ThemeInterface{dark:null}}"
         );
 
         // test wrong case
+        register_shorthands_internal(BTreeMap::new());
         let mut sheet = StyleSheet::default();
         let mut theme = Theme::default();
         let mut color_theme = ColorTheme::default();
@@ -1729,11 +1748,21 @@ mod tests {
         let mut color_theme = sheet::theme::ColorTheme::default();
         color_theme.add_color("primary", "#ff0000");
         theme.add_color_theme("default", color_theme);
+        let shorthands = BTreeMap::from([(
+            "insetX".to_string(),
+            vec!["left".to_string(), "right".to_string()],
+        )]);
 
         register_theme_internal(theme);
+        register_shorthands_internal(shorthands);
 
         // Verify the theme was registered
         let default_theme = GLOBAL_STYLE_SHEET.lock().unwrap().theme.get_default_theme();
         assert_eq!(default_theme, Some("default".to_string()));
+        assert_eq!(
+            css::disassemble_property("insetX").collect::<Vec<_>>(),
+            ["left", "right"]
+        );
+        register_shorthands_internal(BTreeMap::new());
     }
 }

--- a/libs/css/src/lib.rs
+++ b/libs/css/src/lib.rs
@@ -16,6 +16,8 @@ pub mod utils;
 
 use std::borrow::Cow;
 use std::collections::BTreeMap;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{LazyLock, RwLock};
 
 use crate::constant::{GLOBAL_ENUM_STYLE_PROPERTY, GLOBAL_STYLE_PROPERTY};
 use crate::debug::is_debug;
@@ -151,6 +153,8 @@ pub fn merge_selector(class_name: &str, selector: Option<&StyleSelector>) -> Str
 pub enum DisassembleProperty {
     /// Mapped arm: iterate the borrowed `&'static [&'static str]` slice.
     Mapped(std::slice::Iter<'static, &'static str>),
+    /// User-defined shorthand properties registered by a build plugin.
+    Custom(std::vec::IntoIter<String>),
     /// Fallback arm: yield a single owned kebab-cased property, then finish.
     Fallback(Option<String>),
 }
@@ -161,6 +165,7 @@ impl Iterator for DisassembleProperty {
     fn next(&mut self) -> Option<Self::Item> {
         match self {
             DisassembleProperty::Mapped(iter) => iter.next().map(|s| Cow::Borrowed(*s)),
+            DisassembleProperty::Custom(iter) => iter.next().map(Cow::Owned),
             DisassembleProperty::Fallback(slot) => slot.take().map(Cow::Owned),
         }
     }
@@ -168,6 +173,7 @@ impl Iterator for DisassembleProperty {
     fn size_hint(&self) -> (usize, Option<usize>) {
         match self {
             DisassembleProperty::Mapped(iter) => iter.size_hint(),
+            DisassembleProperty::Custom(iter) => iter.size_hint(),
             DisassembleProperty::Fallback(slot) => {
                 let n = usize::from(slot.is_some());
                 (n, Some(n))
@@ -180,6 +186,19 @@ impl ExactSizeIterator for DisassembleProperty {}
 
 #[must_use]
 pub fn disassemble_property(property: &str) -> DisassembleProperty {
+    if let Some(properties) = HAS_CUSTOM_SHORTHANDS
+        .load(Ordering::Relaxed)
+        .then(|| {
+            CUSTOM_SHORTHANDS
+                .read()
+                .ok()
+                .and_then(|shorthands| shorthands.get(property).cloned())
+        })
+        .flatten()
+    {
+        return DisassembleProperty::Custom(properties.into_iter());
+    }
+
     GLOBAL_STYLE_PROPERTY.get(property).map_or_else(
         || {
             DisassembleProperty::Fallback(Some(
@@ -224,6 +243,41 @@ pub fn disassemble_property(property: &str) -> DisassembleProperty {
             ))
         },
         |v| DisassembleProperty::Mapped(v.iter()),
+    )
+}
+
+static CUSTOM_SHORTHANDS: LazyLock<RwLock<BTreeMap<String, Vec<String>>>> =
+    LazyLock::new(|| RwLock::new(BTreeMap::new()));
+static HAS_CUSTOM_SHORTHANDS: AtomicBool = AtomicBool::new(false);
+
+/// Replace the custom shorthand registry used by style extraction.
+pub fn set_custom_shorthands(shorthands: BTreeMap<String, Vec<String>>) {
+    if let Ok(mut registry) = CUSTOM_SHORTHANDS.write() {
+        let shorthands: BTreeMap<String, Vec<String>> = shorthands
+            .into_iter()
+            .map(|(name, properties)| {
+                let properties = properties
+                    .into_iter()
+                    .flat_map(|property| {
+                        GLOBAL_STYLE_PROPERTY.get(property.as_str()).map_or_else(
+                            || vec![to_kebab_case(&property).into_owned()],
+                            |mapped| mapped.iter().map(|value| (*value).to_string()).collect(),
+                        )
+                    })
+                    .collect();
+                (name, properties)
+            })
+            .collect();
+        HAS_CUSTOM_SHORTHANDS.store(!shorthands.is_empty(), Ordering::Relaxed);
+        *registry = shorthands;
+    }
+}
+
+#[must_use]
+pub fn get_custom_shorthand_names() -> Vec<String> {
+    CUSTOM_SHORTHANDS.read().map_or_else(
+        |_| Vec::new(),
+        |registry| registry.keys().cloned().collect(),
     )
 }
 
@@ -1257,5 +1311,29 @@ mod tests {
         assert_eq!(fallback.size_hint(), (1, Some(1)));
         assert_eq!(fallback.next().as_deref(), Some("some-unmapped-property"));
         assert_eq!(fallback.size_hint(), (0, Some(0)));
+    }
+
+    #[test]
+    #[serial]
+    fn test_custom_shorthand() {
+        set_custom_shorthands(BTreeMap::from([(
+            "insetX".to_string(),
+            vec![
+                "left".to_string(),
+                "marginRight".to_string(),
+                "py".to_string(),
+            ],
+        )]));
+
+        assert_eq!(
+            disassemble_property("insetX").collect::<Vec<_>>(),
+            ["left", "margin-right", "padding-top", "padding-bottom"]
+        );
+
+        set_custom_shorthands(BTreeMap::new());
+        assert_eq!(
+            disassemble_property("insetX").collect::<Vec<_>>(),
+            ["inset-x"]
+        );
     }
 }

--- a/libs/sheet/src/lib.rs
+++ b/libs/sheet/src/lib.rs
@@ -5,7 +5,7 @@ use css::{
     atom_hoist::{atom_hoist_threshold, is_atom_hoist},
     file_map::canonical,
     file_routes::route_count_for_files,
-    sheet_to_classname,
+    get_custom_shorthand_names, sheet_to_classname,
     style_selector::{AtRuleKind, StyleSelector, get_selector_order, global_selector_order},
     theme_tokens::set_theme_token_levels,
     utils::compile_regex,
@@ -640,11 +640,13 @@ impl StyleSheet {
         let typography_keys = collect_keys(&mut self.theme.typography.keys());
         let length_keys = collect_keys(&mut self.theme.length.values().flat_map(|t| t.keys()));
         let shadows_keys = collect_keys(&mut self.theme.shadows.values().flat_map(|t| t.keys()));
+        let shorthand_keys = get_custom_shorthand_names();
 
         if color_keys.is_empty()
             && typography_keys.is_empty()
             && length_keys.is_empty()
             && shadows_keys.is_empty()
+            && shorthand_keys.is_empty()
         {
             String::new()
         } else {
@@ -689,9 +691,27 @@ impl StyleSheet {
                 }
                 contents
             };
+            let shorthand_interface = if shorthand_keys.is_empty() {
+                String::new()
+            } else {
+                format!(
+                    "interface DevupCustomShorthands{{{}}}",
+                    shorthand_keys
+                        .iter()
+                        .map(|key| format!("{}?:DevupProps[\"w\"]", convert_interface_key(key)))
+                        .collect::<Vec<_>>()
+                        .join(";")
+                )
+            };
+            let shorthand_import = if shorthand_keys.is_empty() {
+                String::new()
+            } else {
+                format!("import type{{DevupProps}}from\"{package_name}\";")
+            };
             format!(
-                "import \"{}\";declare module \"{}\"{{interface {}{{{}}}interface {}{{{}}}interface {}{{{}}}interface {}{{{}}}interface {}{{{}}}}}",
+                "import \"{}\";{}declare module \"{}\"{{interface {}{{{}}}interface {}{{{}}}interface {}{{{}}}interface {}{{{}}}{}interface {}{{{}}}}}",
                 package_name,
+                shorthand_import,
                 package_name,
                 color_interface_name,
                 emit_keys(color_keys, true),
@@ -701,6 +721,7 @@ impl StyleSheet {
                 emit_keys(length_keys, true),
                 shadows_interface_name,
                 emit_keys(shadows_keys, true),
+                shorthand_interface,
                 theme_interface_name,
                 emit_keys(theme_keys, false)
             )

--- a/packages/bun-plugin/README.md
+++ b/packages/bun-plugin/README.md
@@ -32,52 +32,46 @@ bun add @devup-ui/react @devup-ui/bun-plugin
 
 ## Usage
 
-### With Bun.build()
+Add the zero-config entry to Bun's preload list:
 
-```typescript
-import { DevupUI, getDevupDefine } from '@devup-ui/bun-plugin'
+```toml
+# bunfig.toml
+[test]
+preload = ["@devup-ui/bun-plugin"]
+```
 
-await Bun.build({
-  entrypoints: ['./src/index.tsx'],
-  outdir: './dist',
-  plugins: [DevupUI()],
-  define: getDevupDefine(),
+## Custom Shorthands
+
+To configure custom shorthands, preload a local module instead of the
+zero-config entry:
+
+```toml
+# bunfig.toml
+[test]
+preload = ["./devup-ui.preload.ts"]
+```
+
+```ts
+// devup-ui.preload.ts
+import { register } from '@devup-ui/bun-plugin/register'
+
+await register({
+  shorthands: {
+    insetX: ['left', 'right'],
+    scrollMarginX: ['scrollMarginLeft', 'scrollMarginRight'],
+  },
 })
 ```
 
-### Configuration Options
+Custom shorthands are plugin configuration, not theme tokens. Every target
+receives the same value, and target names may use camelCase or kebab-case. The
+generated `df/theme.d.ts` provides type completion for component props,
+responsive values, and selectors. Restart Bun after changing the option.
+If `tsconfig.json` only includes your source directory, add `df/*.d.ts` to
+`include`.
 
-```typescript
-import { DevupUI } from '@devup-ui/bun-plugin'
-
-DevupUI({
-  // Package to import components from (default: '@devup-ui/react')
-  package: '@devup-ui/react',
-
-  // CSS directory path (default: 'df/devup-ui')
-  cssDir: 'df/devup-ui',
-
-  // Theme configuration file path (default: 'devup.json')
-  devupFile: 'devup.json',
-
-  // Distribution directory for generated files (default: 'df')
-  distDir: 'df',
-
-  // Enable CSS extraction and transformation (default: true)
-  extractCss: true,
-
-  // Enable debug logging (default: false)
-  debug: false,
-
-  // Additional packages to include in processing (default: [])
-  include: [],
-
-  // Merge all CSS into single file (default: false)
-  singleCss: false,
-
-  // CSS class name prefix (default: undefined)
-  prefix: 'my-prefix',
-})
+```tsx
+<Box insetX={[0, null, 'auto']} _hover={{ insetX: 4 }} />
 ```
 
 ## Features

--- a/packages/bun-plugin/package.json
+++ b/packages/bun-plugin/package.json
@@ -21,7 +21,7 @@
   "version": "1.0.12",
   "scripts": {
     "lint": "eslint",
-    "build": "tsc && bun build --target node src/index.cjs.ts --production --env=disable --outfile dist/index.cjs --format cjs --packages external && bun build --target node src/index.ts --production --env=disable --outfile dist/index.mjs --format esm --packages external",
+    "build": "tsc && bun build --target node src/index.cjs.ts --production --env=disable --outfile dist/index.cjs --format cjs --packages external && bun build --target node src/index.ts --production --env=disable --outfile dist/index.mjs --format esm --packages external && bun build --target node src/register.ts --production --env=disable --outfile dist/register.cjs --format cjs --packages external && bun build --target node src/register.ts --production --env=disable --outfile dist/register.mjs --format esm --packages external",
     "test:regression": "cd __regression__ && bun test ./preload-race.bun.ts"
   },
   "publishConfig": {
@@ -35,6 +35,11 @@
       "types": "./dist/index.d.ts",
       "import": "./dist/index.mjs",
       "require": "./dist/index.cjs"
+    },
+    "./register": {
+      "types": "./dist/register.d.ts",
+      "import": "./dist/register.mjs",
+      "require": "./dist/register.cjs"
     }
   },
   "files": [

--- a/packages/bun-plugin/src/plugin.ts
+++ b/packages/bun-plugin/src/plugin.ts
@@ -4,6 +4,7 @@ import { basename, dirname, join, relative, resolve } from 'node:path'
 
 import {
   createThemeInterfaceArgs,
+  type CustomShorthands,
   loadDevupConfig,
   mergeImportAliases,
 } from '@devup-ui/plugin-utils'
@@ -11,6 +12,7 @@ import {
   codeExtract,
   getThemeInterface,
   hasDevupUI,
+  registerShorthands,
   registerTheme,
   setDebug,
 } from '@devup-ui/wasm'
@@ -22,6 +24,10 @@ const distDir = 'df'
 const cssDir = resolve(distDir, 'devup-ui')
 const singleCss = true
 const importAliases = mergeImportAliases()
+
+export interface DevupUIBunPluginOptions {
+  shorthands?: CustomShorthands
+}
 
 async function writeDataFiles() {
   let theme = {}
@@ -45,7 +51,8 @@ async function writeDataFiles() {
   }
 }
 
-async function initialize() {
+async function initialize({ shorthands }: DevupUIBunPluginOptions = {}) {
+  registerShorthands(shorthands ?? {})
   if (!existsSync(distDir)) await mkdir(distDir, { recursive: true })
   await writeFile(join(distDir, '.gitignore'), '*', 'utf-8')
   await writeDataFiles()
@@ -97,12 +104,12 @@ async function loadSourceFile(filePath: string) {
 // await, preload-driven `bun test` users race the async setup and load sources
 // against the @devup-ui/react runtime stubs (throwing "Cannot run on the
 // runtime").
-function register() {
+function register(options: DevupUIBunPluginOptions = {}) {
   return plugin({
     name: 'devup-ui',
 
     async setup(build) {
-      await initialize()
+      await initialize(options)
       setDebug(true)
 
       // Resolve devup-ui CSS files

--- a/packages/bun-plugin/src/register.ts
+++ b/packages/bun-plugin/src/register.ts
@@ -1,0 +1,2 @@
+export type { DevupUIBunPluginOptions } from './plugin'
+export { register } from './plugin'

--- a/packages/next-plugin/README.md
+++ b/packages/next-plugin/README.md
@@ -164,3 +164,31 @@ const box = <Box _hover={{ bg: ['red', 'blue'] }} />
 // Same
 const box = <Box _hover={[{ bg: 'red' }, { bg: 'blue' }]} />
 ```
+
+## Custom Shorthands
+
+Custom shorthands belong to the plugin options rather than `devup.json` because
+they extend build-time extraction, not design tokens.
+
+```ts
+// next.config.ts
+const nextConfig = {}
+
+export default DevupUI(nextConfig, {
+  shorthands: {
+    insetX: ['left', 'right'],
+    scrollMarginX: ['scrollMarginLeft', 'scrollMarginRight'],
+  },
+})
+```
+
+Every target receives the same value, and target names accept camelCase or
+kebab-case. The generated `df/theme.d.ts` adds type completion for direct,
+responsive, pseudo-selector, and custom-selector usage. Restart Next.js after
+changing the option.
+If your `tsconfig.json` does not already match `df/*.d.ts`, add it (or your
+custom `distDir`) to `include`.
+
+```tsx
+<Box insetX={[0, null, 'auto']} _hover={{ insetX: 4 }} />
+```

--- a/packages/next-plugin/src/plugin.ts
+++ b/packages/next-plugin/src/plugin.ts
@@ -30,6 +30,7 @@ import {
   importFileMap,
   importFileRoutes,
   importSheet,
+  registerShorthands,
   registerTheme,
   setAtomHoist,
   setPrefix,
@@ -72,9 +73,12 @@ export function DevupUI(
       devupFile = 'devup.json',
       include = [],
       prefix,
+      shorthands,
       atomHoist,
       importAliases: userImportAliases,
     } = options
+
+    registerShorthands(shorthands ?? {})
 
     if (prefix) {
       setPrefix(prefix)

--- a/packages/plugin-utils/src/index.ts
+++ b/packages/plugin-utils/src/index.ts
@@ -23,6 +23,7 @@ export {
   getFileNumByFilename,
 } from './shared'
 export type {
+  CustomShorthands,
   DevupConfig,
   DevupTheme,
   ImportAliases,

--- a/packages/plugin-utils/src/shared.ts
+++ b/packages/plugin-utils/src/shared.ts
@@ -1,4 +1,4 @@
-import type { ImportAliases } from './types'
+import type { CustomShorthands, ImportAliases } from './types'
 
 /**
  * Extract file number from a devup-ui CSS filename.
@@ -103,4 +103,6 @@ export interface DevupUIBasePluginOptions {
   singleCss: boolean
   prefix?: string
   importAliases?: ImportAliases
+  /** Build-time aliases that expand one style prop into multiple CSS properties. */
+  shorthands?: CustomShorthands
 }

--- a/packages/plugin-utils/src/types.ts
+++ b/packages/plugin-utils/src/types.ts
@@ -52,6 +52,9 @@ export interface DevupTheme {
   shadows?: ThemeShadows
 }
 
+/** Custom style prop aliases mapped to one or more CSS property names. */
+export type CustomShorthands = Record<string, readonly string[]>
+
 /**
  * Devup configuration file structure (devup.json)
  */

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -153,6 +153,33 @@ Support Theme with Typing
 <Text color="$text" />
 ```
 
+## Custom Shorthand Types
+
+Build plugins accept a `shorthands` option separately from `devup.json`. After
+the plugin runs, it augments `DevupCustomShorthands` in `df/theme.d.ts` so the
+configured names are available on `DevupProps` and nested selector props.
+
+```ts
+DevupUI({
+  shorthands: {
+    insetX: ['left', 'right'],
+  },
+})
+```
+
+```tsx
+<Box
+  insetX={[0, null, 'auto']}
+  _hover={{ insetX: 4 }}
+  selectors={{ '& > *': { insetX: 2 } }}
+/>
+```
+
+Restart the build plugin after changing shorthand configuration so the
+generated declaration is refreshed.
+If `tsconfig.json` only includes `src`, add `df/*.d.ts` (or your plugin's custom
+`distDir`) to `include`.
+
 Support Responsive And Pseudo Selector
 
 You can use responsive and pseudo selector.

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -19,8 +19,9 @@
   "version": "1.0.37",
   "type": "module",
   "scripts": {
-    "lint": "eslint && tsc --noEmit",
-    "build": "tsc && vite build"
+    "lint": "eslint && tsc --noEmit && bun run test:types",
+    "build": "bun run test:types && tsc && vite build",
+    "test:types": "tsc --ignoreConfig --noEmit --strict --jsx react-jsx --moduleResolution bundler --module esnext --target esnext --types bun --skipLibCheck type-tests/custom-shorthand.ts"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -10,6 +10,7 @@ export { ThemeScript } from './components/ThemeScript'
 export { VStack } from './components/VStack'
 export { useTheme } from './hooks/use-theme'
 export type { DevupProps } from './types/props'
+export type { DevupCustomShorthands } from './types/shorthand'
 export type { DevupTheme } from './types/theme'
 export type {
   DevupThemeTypography,

--- a/packages/react/src/types/props/__tests__/index.test-d.ts
+++ b/packages/react/src/types/props/__tests__/index.test-d.ts
@@ -9,6 +9,12 @@ import type {
 } from '..'
 import type { Selectors } from '../selector'
 
+declare module '../../shorthand' {
+  interface DevupCustomShorthands {
+    insetX?: DevupProps['w']
+  }
+}
+
 describe('index', () => {
   it('DevupCommonProps', () => {
     assertType<DevupCommonProps>({
@@ -21,6 +27,20 @@ describe('index', () => {
     expectTypeOf<DevupProps>()
       .toHaveProperty('bg')
       .toEqualTypeOf<ResponsiveValue<Property.Background>>()
+  })
+
+  it('custom shorthand module augmentation', () => {
+    assertType<DevupComponentProps<'div'>>({
+      insetX: [0, null, 'auto'],
+      _hover: {
+        insetX: 4,
+      },
+      selectors: {
+        '& > *': {
+          insetX: '$contentWidth',
+        },
+      },
+    })
   })
 
   it('Selectors', () => {

--- a/packages/react/src/types/props/index.ts
+++ b/packages/react/src/types/props/index.ts
@@ -1,6 +1,7 @@
 import type { Properties } from 'csstype-extra'
 
 import type { ResponsiveValue } from '../responsive-value'
+import type { DevupCustomShorthands } from '../shorthand'
 import type { Merge } from '../utils'
 import type { DevupUiBackgroundProps } from './background'
 import type { DevupUiBorderProps } from './border'
@@ -25,7 +26,8 @@ export interface DevupShortcutsProps
     DevupUiMotionPathProps,
     DevupUiPositionProps,
     DevupUiMaskProps,
-    DevupUiTextProps {}
+    DevupUiTextProps,
+    DevupCustomShorthands {}
 
 export type DevupCommonProps = Merge<
   {

--- a/packages/react/src/types/shorthand.ts
+++ b/packages/react/src/types/shorthand.ts
@@ -1,0 +1,3 @@
+/* eslint-disable @typescript-eslint/no-empty-object-type */
+// biome-ignore lint/suspicious/noEmptyInterface: public module augmentation point.
+export interface DevupCustomShorthands {}

--- a/packages/react/type-tests/custom-shorthand.ts
+++ b/packages/react/type-tests/custom-shorthand.ts
@@ -1,0 +1,29 @@
+import { Box, type DevupProps } from '../src'
+
+// Mirrors the module augmentation emitted to <distDir>/theme.d.ts.
+declare module '../src' {
+  interface DevupCustomShorthands {
+    insetX?: DevupProps['w']
+  }
+}
+
+const customShorthandProps: DevupProps = {
+  insetX: [0, null, 'auto'],
+  _hover: {
+    insetX: 4,
+  },
+  selectors: {
+    '& > *': {
+      insetX: '$contentWidth',
+    },
+  },
+}
+
+const boxProps: Parameters<typeof Box>[0] = {
+  insetX: 'auto',
+  _focus: {
+    insetX: [0, 4],
+  },
+}
+
+export { boxProps, customShorthandProps }

--- a/packages/rsbuild-plugin/README.md
+++ b/packages/rsbuild-plugin/README.md
@@ -164,3 +164,30 @@ const box = <Box _hover={{ bg: ['red', 'blue'] }} />
 // Same
 const box = <Box _hover={[{ bg: 'red' }, { bg: 'blue' }]} />
 ```
+
+## Custom Shorthands
+
+```ts
+// rsbuild.config.ts
+export default defineConfig({
+  plugins: [
+    DevupUI({
+      shorthands: {
+        insetX: ['left', 'right'],
+        scrollMarginX: ['scrollMarginLeft', 'scrollMarginRight'],
+      },
+    }),
+  ],
+})
+```
+
+Custom shorthands are build-plugin options, not theme tokens. Every target
+receives the same value, with camelCase and kebab-case target names supported.
+The generated `df/theme.d.ts` provides type completion for component props,
+responsive values, and selectors. Restart Rsbuild after changing the option.
+If `tsconfig.json` only includes `src`, add `df/*.d.ts` (or your custom
+`distDir`) to `include`.
+
+```tsx
+<Box insetX={[0, null, 'auto']} _hover={{ insetX: 4 }} />
+```

--- a/packages/rsbuild-plugin/src/plugin.ts
+++ b/packages/rsbuild-plugin/src/plugin.ts
@@ -7,6 +7,7 @@ import {
   computeFileReach,
   createNodeModulesExcludeRegex,
   createThemeInterfaceArgs,
+  type CustomShorthands,
   getFileNumByFilename,
   type ImportAliases,
   loadDevupConfig,
@@ -20,6 +21,7 @@ import {
   getThemeInterface,
   importCanonicalMap,
   importFileRoutes,
+  registerShorthands,
   registerTheme,
   setAtomHoist,
   setDebug,
@@ -37,6 +39,7 @@ export interface DevupUIRsbuildPluginOptions {
   include: string[]
   singleCss: boolean
   prefix?: string
+  shorthands?: CustomShorthands
   /**
    * Atom-level route-aware hoisting threshold (min routes sharing an atom for it
    * to hoist into the shared devup-ui.css; clamped to >= 2; omit to disable).
@@ -107,9 +110,11 @@ export const DevupUI = ({
   debug = false,
   singleCss = false,
   prefix,
+  shorthands,
   atomHoist,
   importAliases: userImportAliases,
 }: Partial<DevupUIRsbuildPluginOptions> = {}): RsbuildPlugin => {
+  registerShorthands(shorthands ?? {})
   const importAliases = mergeImportAliases(userImportAliases)
 
   return {

--- a/packages/vite-plugin/README.md
+++ b/packages/vite-plugin/README.md
@@ -164,3 +164,33 @@ const box = <Box _hover={{ bg: ['red', 'blue'] }} />
 // Same
 const box = <Box _hover={[{ bg: 'red' }, { bg: 'blue' }]} />
 ```
+
+## Custom Shorthands
+
+Custom shorthands are build-plugin options, not theme tokens. Every target
+property receives the same value. Target names may use camelCase or CSS
+kebab-case.
+
+```ts
+// vite.config.ts
+export default defineConfig({
+  plugins: [
+    DevupUI({
+      shorthands: {
+        insetX: ['left', 'right'],
+        scrollMarginX: ['scrollMarginLeft', 'scrollMarginRight'],
+      },
+    }),
+  ],
+})
+```
+
+After Vite runs, `df/theme.d.ts` includes the configured prop names. They are
+then type-safe and autocompleted on components, responsive values, pseudo
+selectors, and custom selectors. Restart Vite after changing this option.
+If `tsconfig.json` only includes `src`, add `df/*.d.ts` (or your custom
+`distDir`) to `include`.
+
+```tsx
+<Box insetX={[0, null, 'auto']} _hover={{ insetX: 4 }} />
+```

--- a/packages/vite-plugin/src/plugin.ts
+++ b/packages/vite-plugin/src/plugin.ts
@@ -7,6 +7,7 @@ import {
   computeFileReach,
   createNodeModulesExcludeRegex,
   createThemeInterfaceArgs,
+  type CustomShorthands,
   getFileNumByFilename,
   type ImportAliases,
   listSourceFiles,
@@ -23,6 +24,7 @@ import {
   importCanonicalMap,
   importFileMap,
   importFileRoutes,
+  registerShorthands,
   registerTheme,
   setAtomHoist,
   setDebug,
@@ -189,6 +191,7 @@ export interface DevupUIPluginOptions {
   include: string[]
   singleCss: boolean
   prefix?: string
+  shorthands?: CustomShorthands
   /**
    * Atom-level route-aware hoisting threshold (min routes sharing an atom for
    * it to hoist into the shared devup-ui.css; clamped to >= 2; omit to disable).
@@ -248,9 +251,11 @@ export function DevupUI({
   include = [],
   singleCss = false,
   prefix,
+  shorthands,
   atomHoist,
   importAliases: userImportAliases,
 }: Partial<DevupUIPluginOptions> = {}): PluginOption {
+  registerShorthands(shorthands ?? {})
   setDebug(debug)
   if (prefix) {
     setPrefix(prefix)

--- a/packages/webpack-plugin/README.md
+++ b/packages/webpack-plugin/README.md
@@ -164,3 +164,27 @@ const box = <Box _hover={{ bg: ['red', 'blue'] }} />
 // Same
 const box = <Box _hover={[{ bg: 'red' }, { bg: 'blue' }]} />
 ```
+
+## Custom Shorthands
+
+```ts
+// webpack.config.ts
+new DevupUIWebpackPlugin({
+  shorthands: {
+    insetX: ['left', 'right'],
+    scrollMarginX: ['scrollMarginLeft', 'scrollMarginRight'],
+  },
+})
+```
+
+Custom shorthands extend build-time extraction and are intentionally separate
+from `devup.json`. Every target receives the same value; camelCase and CSS
+kebab-case target names are supported. After Webpack runs, the generated
+`df/theme.d.ts` provides type completion on component props, responsive values,
+and selectors. Restart Webpack after changing the option.
+If `tsconfig.json` only includes `src`, add `df/*.d.ts` (or your custom
+`distDir`) to `include`.
+
+```tsx
+<Box insetX={[0, null, 'auto']} _hover={{ insetX: 4 }} />
+```

--- a/packages/webpack-plugin/src/plugin.ts
+++ b/packages/webpack-plugin/src/plugin.ts
@@ -8,6 +8,7 @@ import {
   computeFileReach,
   createNodeModulesExcludeRegex,
   createThemeInterfaceArgs,
+  type CustomShorthands,
   type ImportAliases,
   listSourceFiles,
   loadDevupConfigSync,
@@ -25,6 +26,7 @@ import {
   importFileMap,
   importFileRoutes,
   importSheet,
+  registerShorthands,
   registerTheme,
   setAtomHoist,
   setDebug,
@@ -42,6 +44,7 @@ export interface DevupUIWebpackPluginOptions {
   include: string[]
   singleCss: boolean
   prefix?: string
+  shorthands?: CustomShorthands
   /**
    * Atom-level route-aware hoisting threshold.
    *
@@ -84,9 +87,11 @@ export class DevupUIWebpackPlugin {
     include = [],
     singleCss = false,
     prefix,
+    shorthands,
     atomHoist,
     importAliases: userImportAliases,
   }: Partial<DevupUIWebpackPluginOptions> = {}) {
+    registerShorthands(shorthands ?? {})
     this.importAliases = mergeImportAliases(userImportAliases)
 
     this.options = {


### PR DESCRIPTION
## Summary
- add plugin-level custom shorthand configuration for Vite, Next.js, Webpack, Rsbuild, and Bun
- expand aliases in the Rust/WASM extraction path and generate React module augmentation for type completion
- cover responsive values, pseudo selectors, and custom selectors with compile-time type tests
- document custom shorthands across the main READMEs, package READMEs, and the landing documentation

## Testing
- cargo test --workspace
- cargo clippy --workspace --all-targets -- -D warnings
- bun test with the global runtime transpiler cache disabled: 5,128 passed, 0 failed
- React type test and package builds
- landing type-check, lint, and production build
- WASM release build and extraction/declaration smoke test

Closes #399