### PR TITLE
Add missing changepack for custom shorthands

### DIFF
--- a/.changepacks/changepack_log_Q7mNx4kP2vLs8aBcD5eRf.json
+++ b/.changepacks/changepack_log_Q7mNx4kP2vLs8aBcD5eRf.json
@@ -1,0 +1,14 @@
+{
+  "changes": {
+    "bindings/devup-ui-wasm/package.json": "Patch",
+    "packages/bun-plugin/package.json": "Patch",
+    "packages/next-plugin/package.json": "Patch",
+    "packages/plugin-utils/package.json": "Patch",
+    "packages/react/package.json": "Patch",
+    "packages/rsbuild-plugin/package.json": "Patch",
+    "packages/vite-plugin/package.json": "Patch",
+    "packages/webpack-plugin/package.json": "Patch"
+  },
+  "note": "Add plugin-configured custom shorthands with generated TypeScript completion",
+  "date": "2026-08-23T13:49:37.8762266Z"
+}


### PR DESCRIPTION
## Summary
- add the changepack omitted from #630
- record Patch releases for the WASM binding, plugin utilities, React, and all supported build plugins
- keep this follow-up limited to a single changepack JSON file

## Validation
- bunx @changepacks/cli check --format json

Follow-up to #630.