### PR TITLE
fix(bun-plugin): write the base CSS the imports resolve to

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -440,7 +440,7 @@
     },
     "packages/components": {
       "name": "@devup-ui/components",
-      "version": "0.1.49",
+      "version": "0.1.50",
       "dependencies": {
         "@devup-ui/react": "workspace:^",
         "clsx": "^2.1",
@@ -558,7 +558,7 @@
     },
     "packages/vite-plugin": {
       "name": "@devup-ui/vite-plugin",
-      "version": "1.0.63",
+      "version": "1.0.64",
       "dependencies": {
         "@devup-ui/plugin-utils": "workspace:^",
         "@devup-ui/wasm": "workspace:^",

--- a/packages/bun-plugin/src/plugin.ts
+++ b/packages/bun-plugin/src/plugin.ts
@@ -10,6 +10,7 @@ import {
 } from '@devup-ui/plugin-utils'
 import {
   codeExtract,
+  getCss,
   getThemeInterface,
   hasDevupUI,
   registerShorthands,
@@ -22,6 +23,7 @@ const libPackage = '@devup-ui/react'
 const devupFile = 'devup.json'
 const distDir = 'df'
 const cssDir = resolve(distDir, 'devup-ui')
+const baseCssFile = join(cssDir, 'devup-ui.css')
 const singleCss = true
 const importAliases = mergeImportAliases()
 
@@ -49,6 +51,17 @@ async function writeDataFiles() {
   if (!existsSync(cssDir)) {
     await mkdir(cssDir, { recursive: true })
   }
+  // `onResolve` points every devup-ui.css import at this file, so it has to
+  // exist before the first source file is loaded. Without it the very first
+  // import fails to resolve and the whole run dies before any style is
+  // collected.
+  if (!existsSync(baseCssFile)) {
+    await writeFile(baseCssFile, getCss(null, false), 'utf-8')
+  }
+}
+
+async function writeBaseCss() {
+  await writeFile(baseCssFile, getCss(null, false), 'utf-8')
 }
 
 async function initialize({ shorthands }: DevupUIBunPluginOptions = {}) {
@@ -82,7 +95,7 @@ async function loadSourceFile(filePath: string) {
   const contents = await Bun.file(filePath).text()
 
   if (hasDevupUI(filePath, contents, libPackage)) {
-    const code = codeExtract(
+    const { code, updatedBaseStyle } = codeExtract(
       filePath,
       contents,
       libPackage,
@@ -92,7 +105,11 @@ async function loadSourceFile(filePath: string) {
       false,
       importAliases,
     )
-    return { contents: code.code, loader }
+    // The extracted styles only reach the browser if they are written out.
+    // Every other plugin does this; here they were collected and dropped, so
+    // the file the imports resolve to stayed whatever it was.
+    if (updatedBaseStyle) await writeBaseCss()
+    return { contents: code, loader }
   }
   return { contents, loader }
 }


### PR DESCRIPTION
## Two problems

**1. The plugin never wrote the file its own imports resolve to.**

`onResolve` maps every `devup-ui.css` import to `df/devup-ui/devup-ui.css`, but `writeDataFiles()` only created the *directory*. `codeExtract` returns the collected styles and `updatedBaseStyle`, and both were discarded:

```ts
const code = codeExtract(...)
return { contents: code.code, loader }   // css, cssFile, updatedBaseStyle dropped
```

So the plugin resolved imports to a path it never produced. It appeared to work only where another plugin had already left a file there. In a checkout without one - a fresh clone, a git worktree, CI - the first import fails to resolve and the run dies before any style is collected.

`plugin.test.ts` already spies on `getCss`, which the source never called.

**2. `registerShorthands` was called without being imported.**

Introduced in #632. The next, vite, rsbuild and webpack plugins all import it from `@devup-ui/wasm`; the bun plugin does not, so it throws `ReferenceError: registerShorthands is not defined` on startup. `bun test packages/bun-plugin` fails on `main` today for this reason.

## Change

- write the base stylesheet on `initialize`, so the first resolve has a target
- refresh it whenever `codeExtract` reports `updatedBaseStyle`, matching `webpack-plugin/src/loader.ts`
- import `registerShorthands` from `@devup-ui/wasm`

## Verification

```
bunx tsc --noEmit -p packages/bun-plugin   exit 0
bun test packages/bun-plugin               12 pass, 0 fail
bun run build                              exit 0
```

On `main` the same test command fails with the ReferenceError.

## How this surfaced

In another repository the frontend suite failed only outside the primary checkout:

```
Cannot find module 'C:\...\<main checkout>\df\devup-ui\devup-ui.css'
  from 'C:\...\<worktree>\...\ProjectRail.tsx'
```

It reproduced on an untouched worktree and on a clean clone of the same commit, and disappeared with `BUN_RUNTIME_TRANSPILER_CACHE_PATH=0` - Bun's transpiler cache is keyed by file content, so identical sources in a second checkout reused a resolution belonging to the first. That is only reachable because the resolved file is absent in the second checkout; once the plugin writes its own base stylesheet, each checkout resolves to a file it actually has.