### PR TITLE
ci: migrate npm publishing to OIDC

### DIFF
--- a/.changepacks/config.json
+++ b/.changepacks/config.json
@@ -1,5 +1,11 @@
 {
   "ignore": ["*", "!packages/*/*", "!bindings/*/package.json"],
   "baseBranch": "main",
-  "latestPackage": null
+  "latestPackage": null,
+  "publish": {
+    "node": "npm publish"
+  },
+  "publishDryRun": {
+    "node": "npm publish --dry-run"
+  }
 }

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,7 +7,8 @@ on:
   pull_request:
     branches:
       - main
-permissions: write-all
+permissions:
+  contents: read
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -127,6 +128,11 @@ jobs:
 
   publish:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      id-token: write
+      pages: write
+      pull-requests: write
     steps:
       - name: Checkout
         uses: actions/checkout@v7
@@ -173,8 +179,6 @@ jobs:
         with:
           registry-url: "https://registry.npmjs.org"
           node-version: 24
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       - run: bun install
       - run: bun run build
       - name: Verify built package entry points
@@ -256,9 +260,19 @@ jobs:
           fail_ci_if_error: true
           files: ./coverage/lcov.info
 
+      # Publishes through npm OIDC trusted publishing. The job's
+      # `id-token: write` permission lets npm exchange GitHub's short-lived OIDC
+      # token, and public packages receive provenance automatically.
+      #
+      # PREREQUISITE: every @devup-ui/* package must be registered as a Trusted
+      # Publisher on npmjs.com against repo dev-five-git/devup-ui and workflow
+      # file `publish.yml`. npm matches that filename exactly, so renaming or
+      # moving this file breaks publishing until the entries are updated.
+      #
+      # The publish command itself is selected in .changepacks/config.json:
+      # changepacks defaults to `bun publish` because this repo has a bun.lock,
+      # and bun cannot do OIDC (oven-sh/bun#22423).
       - uses: changepacks/action@main
         id: changepacks
         with:
           publish: true
-        env:
-          NPM_CONFIG_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary

- switch changepacks Node.js publish and dry-run commands from Bun to npm, because npm CLI supports Trusted Publishing OIDC and Bun does not
- grant the publish job explicit least-required GitHub permissions, including `id-token: write`
- remove `NPM_TOKEN` / `NODE_AUTH_TOKEN` / `NPM_CONFIG_TOKEN` from the workflow
- retain npm's automatic provenance for public packages

## Required before merge

Configure a Trusted Publisher for every publishable package on npmjs.com with:

- Provider: GitHub Actions
- Organization: `dev-five-git`
- Repository: `devup-ui`
- Workflow filename: `publish.yml`
- Environment: leave empty
- Allowed action: `npm publish`

There are 11 packages to configure. `@devup-ui/eslint-plugin@1.0.16` is already published, but it still needs the Trusted Publisher for future releases. Do not merge this PR until all 11 entries are configured; merging triggers the pending ten-package release from main.

## Verification

- `actionlint 1.7.12 .github/workflows/publish.yml`
- `bun run build`
- `bun run lint` (0 errors; 21 existing warnings)
- `bun run test` (5,135 passed, 0 failed)
- changepacks `npm publish --dry-run` for the 10 pending release candidates (10/10 succeeded)
- commit hook repeated lint and the 5,135-test suite successfully

No changepack: this changes CI authentication only and does not change a published package API or runtime artifact.

### npm package checklist

- [ ] [`@devup-ui/wasm`](https://www.npmjs.com/package/@devup-ui/wasm)
- [ ] [`@devup-ui/plugin-utils`](https://www.npmjs.com/package/@devup-ui/plugin-utils)
- [ ] [`@devup-ui/react`](https://www.npmjs.com/package/@devup-ui/react)
- [ ] [`@devup-ui/next-plugin`](https://www.npmjs.com/package/@devup-ui/next-plugin)
- [ ] [`@devup-ui/vite-plugin`](https://www.npmjs.com/package/@devup-ui/vite-plugin)
- [ ] [`@devup-ui/webpack-plugin`](https://www.npmjs.com/package/@devup-ui/webpack-plugin)
- [ ] [`@devup-ui/rsbuild-plugin`](https://www.npmjs.com/package/@devup-ui/rsbuild-plugin)
- [ ] [`@devup-ui/bun-plugin`](https://www.npmjs.com/package/@devup-ui/bun-plugin)
- [ ] [`@devup-ui/components`](https://www.npmjs.com/package/@devup-ui/components)
- [ ] [`@devup-ui/reset-css`](https://www.npmjs.com/package/@devup-ui/reset-css)
- [ ] [`@devup-ui/eslint-plugin`](https://www.npmjs.com/package/@devup-ui/eslint-plugin)
