### PR TITLE
chore: release packages through npm OIDC

### DIFF
--- a/.changepacks/changepack_log_npmOidcRelease20260824.json
+++ b/.changepacks/changepack_log_npmOidcRelease20260824.json
@@ -1,0 +1,17 @@
+{
+  "changes": {
+    "bindings/devup-ui-wasm/package.json": "Patch",
+    "packages/bun-plugin/package.json": "Patch",
+    "packages/components/package.json": "Patch",
+    "packages/eslint-plugin/package.json": "Patch",
+    "packages/next-plugin/package.json": "Patch",
+    "packages/plugin-utils/package.json": "Patch",
+    "packages/react/package.json": "Patch",
+    "packages/reset-css/package.json": "Patch",
+    "packages/rsbuild-plugin/package.json": "Patch",
+    "packages/vite-plugin/package.json": "Patch",
+    "packages/webpack-plugin/package.json": "Patch"
+  },
+  "note": "Publish all npm packages through npm trusted publishing with OIDC provenance",
+  "date": "2026-08-24T07:39:04.5537750Z"
+}


### PR DESCRIPTION
## Summary
- patch-bump all 11 public @devup-ui packages
- ensure the next Update Versions release commit contains the npm trusted-publishing configuration
- publish the next versions through npm OIDC with provenance

## Verification
- changepacks 0.3.4 check: 11 projects detected with patch nextVersion
- bun run build
- pre-commit lint (0 errors; 21 existing warnings)
- bun run test (5135 passed, 0 failed)