### PR TITLE
fix(landing): disable analytics outside production

### DIFF
--- a/apps/landing/src/app/layout.tsx
+++ b/apps/landing/src/app/layout.tsx
@@ -22,6 +22,14 @@ const needsStaticExportRscTransport =
   process.env.NODE_ENV === 'production' &&
   process.env.LANDING_BUILD_MODE !== 'next'
 
+const googleTagManagerScript = `(function(w,d,s,l,i){
+if(w.location.hostname!=='devup-ui.com')return;
+w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});
+var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';
+j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;
+f.parentNode.insertBefore(j,f);
+})(window,document,'script','dataLayer','GTM-PSRKC4QZ')`
+
 export const metadata: Metadata = {
   title: 'Devup UI',
   description: 'Zero Config, Zero FOUC, Zero Runtime, CSS in JS Preprocessor',
@@ -119,15 +127,7 @@ export default function RootLayout({
             data-vinext-static-rsc-transport=""
           />
         )}
-        <script
-          dangerouslySetInnerHTML={{
-            __html: `(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
-new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-})(window,document,'script','dataLayer','GTM-PSRKC4QZ')`,
-          }}
-        />
+        <script dangerouslySetInnerHTML={{ __html: googleTagManagerScript }} />
         <link
           as="font"
           crossOrigin="anonymous"
@@ -164,12 +164,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
         })}
       >
         <noscript>
-          <iframe
-            height="0"
-            src="https://www.googletagmanager.com/ns.html?id=GTM-PSRKC4QZ"
-            style={{ display: 'none', visibility: 'hidden' }}
-            width="0"
-          />
+          <span data-javascript-disabled="" hidden />
         </noscript>
         <ReactLenis options={{ duration: 1.4, allowNestedScroll: true }} root>
           <AnchorScroll />

--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -21,7 +21,9 @@ export async function waitForFontsReady(page: Page): Promise<void> {
   // With scripting disabled, <noscript> contents are parsed into the DOM and
   // browser-context promises cannot advance. The completed load event is the
   // strongest available signal in those SSR-only contexts.
-  if ((await page.locator('noscript iframe').count()) > 0) return
+  if ((await page.locator('noscript [data-javascript-disabled]').count()) > 0) {
+    return
+  }
 
   await page.evaluate(async (fontSpecs) => {
     if (!document.fonts) return
@@ -86,7 +88,9 @@ export async function waitForFontsReady(page: Page): Promise<void> {
  */
 export async function waitForStyleSettle(page: Page): Promise<void> {
   await page.waitForLoadState('load')
-  if ((await page.locator('noscript iframe').count()) > 0) return
+  if ((await page.locator('noscript [data-javascript-disabled]').count()) > 0) {
+    return
+  }
 
   await page.evaluate(async () => {
     const finiteAnimations = document.getAnimations().filter((animation) => {

--- a/e2e/landing-build-integrity.spec.ts
+++ b/e2e/landing-build-integrity.spec.ts
@@ -105,4 +105,25 @@ test.describe('Landing Page - Build Integrity', () => {
   test('page title is set correctly', async ({ page }) => {
     await expect(page).toHaveTitle(/Devup UI/)
   })
+
+  test('Google Tag Manager is disabled outside the production hostname', async ({
+    page,
+  }) => {
+    const tagManagerRequests: string[] = []
+    page.on('request', (request) => {
+      if (new URL(request.url()).hostname === 'www.googletagmanager.com') {
+        tagManagerRequests.push(request.url())
+      }
+    })
+
+    await page.goto('/')
+    await page.waitForLoadState('networkidle')
+
+    expect(new URL(page.url()).hostname).toBe('localhost')
+    expect(tagManagerRequests).toHaveLength(0)
+    expect(await page.evaluate(() => 'dataLayer' in window)).toBe(false)
+    await expect(
+      page.locator('iframe[src*="googletagmanager.com"]'),
+    ).toHaveCount(0)
+  })
 })

--- a/e2e/landing-zero-runtime.spec.ts
+++ b/e2e/landing-zero-runtime.spec.ts
@@ -188,7 +188,7 @@ test.describe('Landing Page - Zero Runtime Validation', () => {
         const nonVarProperties = properties.filter(
           (p) => !p.trim().startsWith('--'),
         )
-        // Allow some inline styles (GTM noscript iframe has display:none, etc.)
+        // Allow a small number of non-variable inline properties.
         if (nonVarProperties.length > 3) {
           suspiciousStyles.push(
             `<${el.tagName.toLowerCase()}>: ${style.substring(0, 100)}`,


### PR DESCRIPTION
## Summary

- Initialize Google Tag Manager only on `devup-ui.com`.
- Remove the no-JavaScript GTM fallback iframe.
- Add localhost regression coverage for blocked analytics requests.

## Validation

- `bun tsc --noEmit -p apps/landing/tsconfig.json`
- `bun eslint apps/landing/src/app/layout.tsx e2e/helpers.ts e2e/landing-build-integrity.spec.ts e2e/landing-zero-runtime.spec.ts`
- `bunx playwright test e2e/landing-build-integrity.spec.ts --grep "Google Tag Manager is disabled"`
- `bunx playwright test e2e/docs-pages.spec.ts --grep "header has Docs link"`

Note: the repository pre-commit coverage stage could not complete in this Windows environment because Cargo reported a closed-pipe/cache dependency error for `zerocopy_derive`.
