### PR TITLE
fix: unblock changepacks publishing

### DIFF
--- a/.changepacks/changepack_log_turboProfileRelease20260830.json
+++ b/.changepacks/changepack_log_turboProfileRelease20260830.json
@@ -1,0 +1,17 @@
+{
+  "changes": {
+    "bindings/devup-ui-wasm/package.json": "Patch",
+    "packages/bun-plugin/package.json": "Patch",
+    "packages/components/package.json": "Patch",
+    "packages/eslint-plugin/package.json": "Patch",
+    "packages/next-plugin/package.json": "Patch",
+    "packages/plugin-utils/package.json": "Patch",
+    "packages/react/package.json": "Patch",
+    "packages/reset-css/package.json": "Patch",
+    "packages/rsbuild-plugin/package.json": "Patch",
+    "packages/vite-plugin/package.json": "Patch",
+    "packages/webpack-plugin/package.json": "Patch"
+  },
+  "note": "Improve Turbopack build performance with lite WASM prewarming, align React 19 behavior, and update package toolchains",
+  "date": "2026-08-29T16:26:58.980Z"
+}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -229,7 +229,12 @@ jobs:
       - name: Format Rollback
         run: |
           rm -rf .rustfmt.toml
-          cargo fmt
+          # Formatting with the temporary coverage config and then with the
+          # default config is not a reversible round trip. Restore the exact
+          # checked-in sources so changepacks can safely switch commits.
+          git restore --source=HEAD --staged --worktree -- .
+          cargo fmt --all -- --check
+          git diff --exit-code
       - name: Build Landing
         run: |
           bun run --filter @devup-ui/components build-storybook
@@ -301,6 +306,8 @@ jobs:
       # Bun packs each workspace so dependency ranges are materialized, then
       # npm publishes that tarball with OIDC (Bun cannot do OIDC itself:
       # oven-sh/bun#22423).
+      - name: Verify clean publish checkout
+        run: git diff --exit-code
       - uses: changepacks/action@main
         id: changepacks
         with:


### PR DESCRIPTION
## Summary

- restore the exact checked-in worktree after the temporary coverage rustfmt pass
- assert a clean checkout before `changepacks/action` switches release commits
- add the missing patch changepack for all 11 public packages changed by #645

## Root cause

The coverage step formats Rust sources with a temporary wide rustfmt configuration. Running default rustfmt afterward is not a reversible round trip, so `libs/extractor/src/extractor/extract_global_style_from_expression.rs` remained modified. `changepacks/action` then failed when checking out the previous release commit.

## Validation

- reproduced the temporary formatter dirtying the Rust worktree, including the file from the failed deployment
- verified `git restore --source=HEAD --staged --worktree -- .` returns the checkout to an exact clean state
- `cargo fmt --all -- --check`
- `bun run lint`
- `bun run changepacks check --format json`: all 11 packages are `changed: true` with patch `nextVersion`
- commit hook: Rust coverage 98.22%; Bun 5161 passed, 0 failed, 100% JS/TS function and line coverage
- `bun.lock` unchanged

After merge, changepacks should create/update the version PR. Merging that version PR triggers the actual npm publication.