### PR TITLE
fix(next-plugin): resolve WASM in Bun isolated installs

### DIFF
--- a/.changepacks/changepack_log_fixWasmLiteResolution20260830.json
+++ b/.changepacks/changepack_log_fixWasmLiteResolution20260830.json
@@ -3,5 +3,5 @@
     "packages/next-plugin/package.json": "Patch"
   },
   "note": "Fall back to the full WASM engine when an installed @devup-ui/wasm package does not expose the lite entry point",
-  "date": "2026-08-30T00:00:00.000Z"
+  "date": "2026-08-29T18:49:53.133Z"
 }


### PR DESCRIPTION
## Summary
- resolve runtime dependencies from the physical @devup-ui/next-plugin install location so Bun isolated installs can find non-hoisted WASM
- retain the lite-to-full fallback for older WASM packages
- add a Bun-style isolated node_modules regression fixture
- make the changepack discoverable so changepacks releases 1.0.85

## Verification
- 132 next-plugin tests pass
- next-plugin build passes
- targeted ESLint passes
- packed next-plugin loads WASM after an isolated Bun install
- changepacks calculates @devup-ui/next-plugin 1.0.84 → 1.0.85