### PR TITLE
chore: add changepacks for the absolute CSS path fixes

### DIFF
--- a/.changepacks/changepack_log_Q2rgI4I5CvrWgaizpS24B.json
+++ b/.changepacks/changepack_log_Q2rgI4I5CvrWgaizpS24B.json
@@ -1,0 +1,7 @@
+{
+  "changes": {
+    "packages/rsbuild-plugin/package.json": "Patch"
+  },
+  "note": "Emit the extracted stylesheet import relative to the importing file instead of an absolute path",
+  "date": "2026-09-09T02:33:46.141063900Z"
+}

--- a/.changepacks/changepack_log_nD6b_45FKd0miP08XC5KZ.json
+++ b/.changepacks/changepack_log_nD6b_45FKd0miP08XC5KZ.json
@@ -1,0 +1,7 @@
+{
+  "changes": {
+    "packages/bun-plugin/package.json": "Patch"
+  },
+  "note": "Resolve the extracted stylesheet to a virtual id so parallel checkouts stop importing each other's CSS",
+  "date": "2026-09-09T02:33:25.632377900Z"
+}


### PR DESCRIPTION
Follow-up to #657, which merged without changepack entries. Without them the release workflow has nothing to act on, so main still carries the pre-fix versions and no "Update versions" PR is produced.

## What this adds

Two patch entries, one per package actually changed by #657:

| Package | | |
| --- | --- | --- |
| `@devup-ui/bun-plugin` | v1.0.16 | v1.0.17 |
| `@devup-ui/rsbuild-plugin` | v1.0.62 | v1.0.63 |

Verified against this branch:

```
$ bunx @changepacks/cli check
[Node.js] @devup-ui/bun-plugin (v1.0.16 → v1.0.17) - packages/bun-plugin/package.json (changed)
[Node.js] @devup-ui/rsbuild-plugin (v1.0.62 → v1.0.63) - packages/rsbuild-plugin/package.json
```

The other nine projects are correctly left untouched.

## Note on generation

Generated with `bunx @changepacks/cli`, then narrowed. `-y` selects all 11 projects, which would publish nine packages this change does not touch — worth knowing for anyone scripting it non-interactively.

## What shipped in #657

Both fixes remove a machine-absolute CSS path from transformed module text:

- **bun-plugin** — `onResolve` returned `<cwd>/df/devup-ui/devup-ui.css`, and Bun bakes plugin-resolved specifiers into a machine-wide transpiler cache keyed by module contents alone. Parallel checkouts of one repository share cache entries, so every checkout but the first imported another worktree's stylesheet and its whole `bun test` run failed. Now resolved to a virtual namespaced id.
- **rsbuild-plugin** — the non-atom path (the default) passed the absolute `cssDir` to `codeExtract`, making transform output depend on checkout location. Now relative to the importer, matching next/webpack/vite.
