### PR TITLE
fix(bun-plugin): emit extracted CSS from clean checkouts

### DIFF
--- a/packages/bun-plugin/__regression__/css-emit.bun.ts
+++ b/packages/bun-plugin/__regression__/css-emit.bun.ts
@@ -1,0 +1,70 @@
+import { existsSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join, resolve } from 'node:path'
+
+import { expect, it } from 'bun:test'
+
+const pluginEntry = resolve(import.meta.dir, '..', 'dist', 'index.mjs')
+
+// Separate processes keep the real WASM sheet and plugin hooks isolated from
+// the root suite's mocks. Every process starts without a df directory.
+it.each(['empty theme', 'configured theme', 'extracted styles'])(
+  'emits an importable stylesheet from a clean checkout: %s',
+  (scenario) => {
+    const cwd = mkdtempSync(join(tmpdir(), 'devup-css-emit-'))
+    try {
+      writeFileSync(join(cwd, 'bunfig.toml'), '')
+      if (scenario === 'configured theme') {
+        writeFileSync(
+          join(cwd, 'devup.json'),
+          JSON.stringify({
+            theme: { colors: { default: { primary: '#123456' } } },
+          }),
+        )
+      }
+      const widths = Array.from({ length: 8 }, (_, i) => 101 + i)
+      for (const width of widths) {
+        writeFileSync(
+          join(cwd, `fixture-${width}.ts`),
+          `import { css } from '@devup-ui/react'
+export const cls = css({ width: '${width}px' })
+`,
+        )
+      }
+      writeFileSync(
+        join(cwd, 'check.ts'),
+        `import { existsSync, readFileSync } from 'node:fs'
+import { expect } from 'bun:test'
+
+expect(existsSync('df')).toBe(false)
+await import(${JSON.stringify(pluginEntry.replaceAll('\\', '/'))})
+const cssPath = './df/devup-ui/devup-ui.css'
+${
+  scenario === 'extracted styles'
+    ? `const widths = ${JSON.stringify(widths)}
+const modules = await Promise.all(widths.map(width => import('./fixture-' + width + '.ts')))
+for (const mod of modules) expect(mod.cls).toBeTruthy()
+const css = readFileSync(cssPath, 'utf-8')
+for (const width of widths) expect(css).toContain('width:' + width + 'px')`
+    : `expect(existsSync(cssPath)).toBe(true)
+${scenario === 'configured theme' ? "expect(readFileSync(cssPath, 'utf-8')).toContain('--primary:#123456')" : ''}`
+}
+await import(cssPath)
+`,
+      )
+      expect(existsSync(join(cwd, 'df'))).toBe(false)
+      const result = Bun.spawnSync([process.execPath, 'run', 'check.ts'], {
+        cwd,
+        stdout: 'pipe',
+        stderr: 'pipe',
+        env: { ...process.env, BUN_RUNTIME_TRANSPILER_CACHE_PATH: '0' },
+      })
+      expect(
+        result.exitCode,
+        result.stdout.toString() + result.stderr.toString(),
+      ).toBe(0)
+    } finally {
+      rmSync(cwd, { recursive: true, force: true })
+    }
+  },
+)

--- a/packages/bun-plugin/__regression__/css-emit.md
+++ b/packages/bun-plugin/__regression__/css-emit.md
@@ -1,0 +1,62 @@
+# Bun CSS emission regression
+
+The source at `6f9079ec` already resolves injected CSS imports to a path-free
+virtual module (`src/css-id.ts`) and loads it as an empty JavaScript module.
+That fixes Bun runtime loading and cross-worktree transpiler-cache isolation,
+but `writeDataFiles()` only creates the CSS directory and `loadSourceFile()`
+discards extracted CSS. No stylesheet is written.
+
+The other plugins have different bundler lifecycles:
+
+- Next initializes `devup-ui.css` with `getCss(null, false)` and refreshes CSS
+  through its loaders/coordinator.
+- Webpack writes initial CSS in watch mode, writes extracted CSS in its source
+  loader, serves CSS through its CSS loader, and writes the final base sheet
+  after a successful build.
+- Vite creates the directory before its initial base stylesheet, materializes
+  CSS imports during transformation, and serves/finalizes CSS from `getCss`.
+- Rsbuild materializes stylesheet imports during transformation and serves
+  their contents through its CSS transform.
+
+Bun uses `singleCss = true`, so its artifact is `df/devup-ui/devup-ui.css`.
+Initialize it after directory creation with actual theme CSS, then refresh it
+from `getCss(null, false)` after extraction. A placeholder alone would discard
+the styles, since Bun's virtual runtime module intentionally contains no CSS.
+Keep virtual resolution for cache isolation. No shared utility is needed for
+this small change: the other plugins' emission timing and loaders differ.
+
+Run `bun run build`, then
+`bun run --filter @devup-ui/bun-plugin test:regression`.
+The CSS regression runs isolated Bun processes in temporary directories without
+`df`, using the built plugin and real WASM. It checks initial emission with and
+without a theme, parallel extraction of eight distinct styles, and CSS imports.
+It disables the transpiler cache for these cold-start cases; the existing
+worktree-isolation regression continues to exercise the shared cache.
+
+## Verification (Windows, Bun 1.4.1)
+
+Before implementation:
+
+- Initial `bun test`: 0 pass, 66 fail/errors because workspace build artifacts
+  were missing. Initial `bun run lint`: Rust checks passed; ESLint could not
+  load the unbuilt local ESLint plugin.
+- Initial `bun run test`: Rust tests passed, coverage 98.21% (8572/8728 lines);
+  the Bun phase failed because build artifacts were still missing.
+- `bun run build`: passed.
+- Prepared `bun test`: 5180 pass, 0 fail; 87 snapshots; 100% function/line
+  coverage under the existing repository configuration.
+- Prepared `bun run lint`: passed (format, Clippy, ESLint).
+- Regression RED, before production edits: 2 existing tests passed; all 3 new
+  cases failed because the stylesheet did not exist (`false` / `ENOENT`).
+
+After implementation:
+
+- `bun run --filter @devup-ui/bun-plugin build`: passed.
+- `bun run --filter @devup-ui/bun-plugin test:regression`: 5 pass, 0 fail,
+  including the unchanged preload and worktree-cache regressions.
+- `bun run test`: passed. Rust coverage remains 98.21% (8572/8728 lines,
+  +0.00%); Bun remains 5180 pass, 0 fail, 87 snapshots and 100% function/line
+  coverage. No coverage configuration or existing assertions were changed.
+- Running Tarpaulin and Clippy concurrently caused transient missing `target`
+  fingerprint files on Windows. Validation commands were rerun sequentially.
+- Sequential `bun run lint`: passed, matching the prepared baseline.

--- a/packages/bun-plugin/package.json
+++ b/packages/bun-plugin/package.json
@@ -22,7 +22,7 @@
   "scripts": {
     "lint": "eslint",
     "build": "bun ../../node_modules/@typescript/native/bin/tsc && bun build --target node src/index.cjs.ts --production --env=disable --outfile dist/index.cjs --format cjs --packages external && bun build --target node src/index.ts --production --env=disable --outfile dist/index.mjs --format esm --packages external && bun build --target node src/register.ts --production --env=disable --outfile dist/register.cjs --format cjs --packages external && bun build --target node src/register.ts --production --env=disable --outfile dist/register.mjs --format esm --packages external",
-    "test:regression": "cd __regression__ && bun test ./preload-race.bun.ts ./worktree-isolation.bun.ts"
+    "test:regression": "cd __regression__ && bun test ./preload-race.bun.ts ./worktree-isolation.bun.ts ./css-emit.bun.ts"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/bun-plugin/src/plugin.ts
+++ b/packages/bun-plugin/src/plugin.ts
@@ -1,4 +1,4 @@
-import { existsSync } from 'node:fs'
+import { existsSync, writeFileSync } from 'node:fs'
 import { mkdir, writeFile } from 'node:fs/promises'
 import { dirname, join, relative, resolve } from 'node:path'
 
@@ -10,6 +10,7 @@ import {
 } from '@devup-ui/plugin-utils'
 import {
   codeExtract,
+  getCss,
   getThemeInterface,
   hasDevupUI,
   registerShorthands,
@@ -51,6 +52,7 @@ async function writeDataFiles() {
   if (!existsSync(cssDir)) {
     await mkdir(cssDir, { recursive: true })
   }
+  await writeFile(join(cssDir, 'devup-ui.css'), getCss(null, false), 'utf-8')
 }
 
 async function initialize({ shorthands }: DevupUIBunPluginOptions = {}) {
@@ -89,6 +91,10 @@ async function loadSourceFile(filePath: string) {
       false,
       importAliases,
     )
+    // singleCss stores every extracted style in the base sheet. Finish the
+    // write before returning the injected import; synchronous writes also keep
+    // concurrent source loads from overwriting a newer sheet with an older one.
+    writeFileSync(join(cssDir, 'devup-ui.css'), getCss(null, false), 'utf-8')
     return { contents: code.code, loader }
   }
   return { contents, loader }


### PR DESCRIPTION
## 문제

`bun-plugin`이 추출한 CSS를 **버린다.**

`writeDataFiles()`는 CSS 디렉토리만 만들고, `loadSourceFile()`은 `codeExtract` 결과의 스타일을 기록하지 않는다. 그 결과 `df/devup-ui/devup-ui.css`가 생성되지 않는다.

소스는 이미 주입된 CSS import를 경로 없는 가상 모듈(`src/css-id.ts`)로 해석해 Bun 런타임 로딩과 워크트리 간 트랜스파일러 캐시 격리를 해결해 두었다. 다만 **스타일시트 자체를 쓰는 단계가 없다.**

## 다른 플러그인과의 대조

| 플러그인 | CSS 처리 |
| --- | --- |
| Next | `getCss(null, false)`로 초기화 후 로더/코디네이터로 갱신 |
| Webpack | watch 초기 기록, 소스 로더에서 추출 CSS 기록, 빌드 후 최종 시트 |
| Vite | 디렉토리 선생성 후 초기 시트, 변환 중 구체화, `getCss`로 마감 |
| Rsbuild | 변환 중 스타일시트 import 구체화, CSS transform으로 제공 |
| **Bun** | **디렉토리만 생성, 추출 CSS 폐기** |

## 수정

Bun은 `singleCss = true`라 산출물이 `df/devup-ui/devup-ui.css` 하나다.

```ts
// 디렉토리 생성 직후 초기화
await writeFile(join(cssDir, 'devup-ui.css'), getCss(null, false), 'utf-8')

// 추출 직후 갱신
writeFileSync(join(cssDir, 'devup-ui.css'), getCss(null, false), 'utf-8')
```

추출 후 갱신에 **동기 쓰기**를 쓴 이유는 주석으로 남겼다. 동시 소스 로드가 최신 시트를 이전 시트로 덮어쓰는 것을 막는다.

빈 플레이스홀더로 대체하지 않았다. Bun의 가상 런타임 모듈은 의도적으로 CSS를 담지 않으므로 플레이스홀더만 두면 스타일이 그대로 버려진다. 캐시 격리를 위한 가상 해석은 유지했다.

다른 플러그인의 동작은 변경하지 않았다. 방출 시점과 로더가 서로 달라 공통 유틸로 묶지 않았다.

## 회귀 테스트

`packages/bun-plugin/__regression__/css-emit.bun.ts`를 추가하고 `test:regression`에 연결했다.

`df`가 없는 임시 디렉토리에서 **격리된 Bun 프로세스**로 실행하며, 빌드된 플러그인과 실제 WASM을 쓴다. 테마 유무별 초기 방출, 서로 다른 스타일 8개의 병렬 추출, CSS import를 확인한다. 콜드 스타트 검증을 위해 이 케이스들만 트랜스파일러 캐시를 끄고, 기존 worktree-isolation 회귀는 공유 캐시를 계속 사용한다.

## 검증 (Windows, Bun 1.4.1)

수정 전 RED: 기존 2개 통과, 신규 3개는 스타일시트 부재로 실패(`false` / `ENOENT`).

수정 후:
- `bun run --filter @devup-ui/bun-plugin test:regression`: **5 pass / 0 fail**
- `bun run test`: **5180 pass / 0 fail**, 87 snapshots, 함수·라인 커버리지 100%
- Rust 커버리지 **98.21% (8572/8728, +0.00%)**
- `bun run lint`: 통과 (format, Clippy, ESLint)

커버리지 설정과 기존 단언은 변경하지 않았다.

Tarpaulin과 Clippy를 동시 실행하면 Windows에서 `target` fingerprint 파일이 일시적으로 사라져 검증 명령을 순차 재실행했다.

## 발견 경위

`girok-space`에서 컴포넌트를 import하는 테스트 파일이 모듈 로드 단계에서 대량으로 실패하던 것을 추적하다 발견했다. 해당 저장소에서 스타일시트를 수동 생성하자 `124 pass / 466 fail` → `185 pass / 413 fail`로 61개가 살아났다.