### PR TITLE
chore: add changepack for Bun CSS emission fix

### DIFF
--- a/.changepacks/changepack_log_bun_css_emit.json
+++ b/.changepacks/changepack_log_bun_css_emit.json
@@ -1,0 +1,7 @@
+{
+  "changes": {
+    "packages/bun-plugin/package.json": "Patch"
+  },
+  "note": "Emit the initial theme and extracted CSS stylesheet when running Bun in a clean checkout",
+  "date": "2026-09-10T08:00:00.000Z"
+}


### PR DESCRIPTION
The Bun CSS emission fix in #660 was merged without a changepack, so it was not scheduled for release. Add a patch entry for `@devup-ui/bun-plugin` to release the fix as 1.0.18.

Validation: `bunx @changepacks/cli check` identifies only bun-plugin as changed (1.0.17 → 1.0.18). The commit hook runs the repository's full lint and test commands.
